### PR TITLE
Simple build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Highlight reel:
 - ["IO Modules"](backends/aws-lambda/iomod) (eventually to be shipped as packages/plugins) provide an interface for both the host and WASM guest,
   allowing guests to **safely** make calls to the outside world without needing elevated access.
 - Currently focusing on support for guests written in **Rust**, but other languages targeting WASM are possible. PR's welcome!
-- IO mods are **asynchronous** (using [tokio](https://github.com/tokio-rs/tokio)), and guests written using Rust fully support **async/await**.
+- IOmods are **asynchronous** (using [tokio](https://github.com/tokio-rs/tokio)), and guests written using Rust fully support **async/await**.
 - Planned support for multiple backends, but the focus is currently on _AWS Lambda_
 - Built using the [Wasmer](https://wasmer.io) interpreter
 
@@ -41,6 +41,16 @@ your dependency supply chain.
 It's still early days, so there's nothing in this repo right now which I would characterize as ergonomic. In terms of
 plans in this area, I intend for the tooling to abstract away as much of the underlying backend as possible (ie AWS vs Azure).
 
+# Building
+
+To build using your local Cargo installation, run  
+`./build.rb build local {optional Cargo build args}`
+
+To generate a build of `bootstrap` to deploy to AWS Lambda, run  
+`./build.rb build deploy (optional Cargo build args}`
+
+If using Ruby as a build front-end is problematic in your environment, please [file an issue](https://github.com/akkoro/assemblylift/issues/new?labels=bug)!
+
 # Roadmap
 
 ## 0.1
@@ -54,10 +64,9 @@ plans in this area, I intend for the tooling to abstract away as much of the und
 
 ## 0.2
 
-- [ ] Async memory manager
-  - [ ] Macros
-  - [ ] Project init via CLI
-  - [ ] More examples
+- [ ] Proper implementation of [Threader](core/event/src/threader.rs) memory manager
+- [ ] Macros for iomod implementation
+- [ ] More examples
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If using Ruby as a build front-end is problematic in your environment, please [f
 
 ## 0.2
 
-- [ ] Proper implementation of [Threader](core/event/src/threader.rs) memory manager
+- [ ] Proper implementation of [Threader](/core/event/src/threader.rs) memory manager
 - [ ] Macros for iomod implementation
 - [ ] More examples
 

--- a/build.rb
+++ b/build.rb
@@ -1,0 +1,86 @@
+#!/usr/bin/ruby
+
+#
+# The AssemblyLift build script
+#
+
+require 'shellwords'
+
+# Check environment
+# Need: docker, cargo, rustc
+#
+
+def check_exists(executable)
+  `#{executable} &> /dev/null`
+
+  if $?.exitstatus != 0
+    puts "Could not exec #{executable}"
+    return false
+  else
+    puts "Found #{executable}!"
+    return true
+  end
+end
+
+def die(message)
+  puts "DIE: " + message
+  exit(-1)
+end
+
+has_docker = check_exists("docker")
+has_cargo = check_exists("cargo")
+has_rustc = check_exists("rustc")
+
+if not has_docker or not has_cargo or not has_rustc
+  die("Missing build dependency, exiting...")
+end
+
+DOCKER = "docker"
+CARGO = "cargo"
+RUSTC = "rustc"
+
+# Check first argument
+
+args = %w[build test]
+arg_error_string = "build.rb must be run with one of #{args} as an argument"
+
+unless ARGV[0]
+  die(arg_error_string)
+end
+
+cmd = ARGV[0]
+
+unless args.include?(cmd)
+  die(arg_error_string)
+end
+
+# Switch on commands
+case cmd
+when "build"
+  build_args = %w[local deploy]
+  build_arg_error_string = "build.rb build command must be run with one of #{build_args} as an argument"
+
+  build_cmd = ARGV[1]
+
+  unless build_args.include?(build_cmd)
+    die(build_arg_error_string)
+  end
+
+  case build_cmd
+  when "local"
+    super_args = ARGV[2..ARGV.length].map{|arg| Shellwords.escape arg}.join(' ')
+    `#{CARGO} build #{super_args}`
+
+  when "deploy"
+    die("deploy-mode build is not yet implemented")
+
+  else
+    die(build_arg_error_string)
+  end
+
+when "test"
+  die("test is not yet implemented")
+
+else
+  die(arg_error_string)
+end

--- a/build.rb
+++ b/build.rb
@@ -83,6 +83,7 @@ when "build"
     puts "Building deployment-ready build..."
     `#{DOCKER} build . --tag #{tag}`
     `#{DOCKER} run --rm --entrypoint cat #{tag}  /usr/src/assembly-lift/target/release/bootstrap > ./bootstrap`
+    puts "Done! Build artifact copied to project root."
 
   else
     die(build_arg_error_string)


### PR DESCRIPTION
This adds a simple Ruby script that accepts a couple of arguments, to allow building using either local Cargo, or Docker.

`build.rb build local` is a simple wrapper around Cargo build. Additional arguments will be passed to `cargo build` (ex. `build.rb build local --release`).

`build.rb build deploy` will build with `--release` against Amazon Linux, and copy the resulting binary to the root directory on the host.