### PR TITLE
CLI scaffolding

### DIFF
--- a/.idea/assemblylift.iml
+++ b/.idea/assemblylift.iml
@@ -13,6 +13,7 @@
       <sourceFolder url="file://$MODULE_DIR$/backends/aws-lambda/iomod/guest/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/backends/aws-lambda/host/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/examples/todo/create/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/cli/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,6 +333,8 @@ name = "cli"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "handlebars",
+ "serde_json",
 ]
 
 [[package]]
@@ -759,6 +761,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "handlebars"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba758d094d31274eb49d15da6f326b96bf3185239a6359bf684f3d5321148900"
+dependencies = [
+ "log",
+ "pest",
+ "pest_derive",
+ "quick-error",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -931,6 +947,12 @@ checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matches"
@@ -1200,6 +1222,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
+dependencies = [
+ "maplit",
+ "pest",
+ "sha-1",
+]
+
+[[package]]
 name = "pin-project"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,6 +1328,12 @@ checksum = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
 dependencies = [
  "unicode-xid",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -1670,6 +1741,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "fake-simd",
+ "opaque-debug",
+]
+
+[[package]]
 name = "sha1"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1986,6 +2069,12 @@ name = "typenum"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicase"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "arc-swap"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,34 +315,17 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.0-beta.1"
+version = "2.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "860643c53f980f0d38a5e25dfab6c3c93b2cb3aa1fe192643d17a293c6c41936"
+checksum = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
 dependencies = [
+ "ansi_term",
  "atty",
  "bitflags",
- "clap_derive",
- "indexmap",
- "lazy_static",
- "os_str_bytes",
  "strsim",
- "termcolor",
  "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.0.0-beta.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb51c9e75b94452505acd21d929323f5a5c6c4735a852adbd39ef5fb1b014f30"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -767,15 +759,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "heck"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1177,12 +1160,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06de47b848347d8c4c94219ad8ecd35eb90231704b067e67e6ae2e36ee023510"
-
-[[package]]
 name = "page_size"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1265,32 +1242,6 @@ name = "ppv-lite86"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
-
-[[package]]
-name = "proc-macro-error"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "syn-mid",
- "version_check",
-]
 
 [[package]]
 name = "proc-macro-hack"
@@ -1833,9 +1784,9 @@ checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "subtle"
@@ -1852,17 +1803,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
-]
-
-[[package]]
-name = "syn-mid"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1883,15 +1823,6 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.8",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -2082,12 +2013,6 @@ checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 dependencies = [
  "smallvec",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 
 [[package]]
 name = "unicode-width"
@@ -2367,15 +2292,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi 0.3.8",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "autocfg"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +302,45 @@ dependencies = [
  "num-traits",
  "serde",
  "time 0.1.42",
+]
+
+[[package]]
+name = "clap"
+version = "3.0.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "860643c53f980f0d38a5e25dfab6c3c93b2cb3aa1fe192643d17a293c6c41936"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim",
+ "termcolor",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb51c9e75b94452505acd21d929323f5a5c6c4735a852adbd39ef5fb1b014f30"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cli"
+version = "0.1.0"
+dependencies = [
+ "clap",
 ]
 
 [[package]]
@@ -717,6 +767,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,6 +1177,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06de47b848347d8c4c94219ad8ecd35eb90231704b067e67e6ae2e36ee023510"
+
+[[package]]
 name = "page_size"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,6 +1265,32 @@ name = "ppv-lite86"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+
+[[package]]
+name = "proc-macro-error"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "syn-mid",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro-hack"
@@ -1741,6 +1832,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "subtle"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,6 +1852,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "syn-mid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1775,6 +1883,24 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1958,6 +2084,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1979,6 +2117,12 @@ name = "vcpkg"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -2223,6 +2367,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi 0.3.8",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "assemblylift-cli"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "handlebars",
+ "serde_json",
+]
+
+[[package]]
 name = "assemblylift-core"
 version = "0.1.0"
 dependencies = [
@@ -326,15 +335,6 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "cli"
-version = "0.1.0"
-dependencies = [
- "clap",
- "handlebars",
- "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ members = [
     "core/guest",
     "core/event",
     "core/event/guest",
-    "core/event/common"
+    "core/event/common",
+    "cli"
 ]
 exclude = [
     "examples/hello-world",

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ If using Ruby as a build front-end is problematic in your environment, please [f
 - [ ] Proper implementation of [Threader](/core/event/src/threader.rs) memory manager
 - [ ] Macros for iomod implementation
 - [ ] More examples
+- [ ] Logging system
 
 # Contributing
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,3 +12,5 @@ path = "src/main.rs"
 
 [dependencies]
 clap = "2.33.1"
+handlebars = "3.0.1"
+serde_json = "1.0.53"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,4 +11,4 @@ name = "asml"
 path = "src/main.rs"
 
 [dependencies]
-clap = "3.0.0-beta.1"
+clap = "2.33.1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "cli"
+version = "0.1.0"
+authors = ["xlem <xlem@akkoro.io>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[[bin]]
+name = "asml"
+path = "src/main.rs"
+
+[dependencies]
+clap = "3.0.0-beta.1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cli"
+name = "assemblylift-cli"
 version = "0.1.0"
 authors = ["xlem <xlem@akkoro.io>"]
 edition = "2018"

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -1,31 +1,37 @@
 use std::process;
+use std::fs;
+use std::path;
+use std::io;
 
-use clap::ArgMatches;
+use clap::{crate_version, ArgMatches};
 use handlebars::{to_json, Handlebars};
 use serde_json::value::{Map, Value as Json};
+use std::error::Error;
+use std::io::Write;
+use std::path::PathBuf;
 
 pub fn init(matches: Option<&ArgMatches>) {
-    if let Some(matches) = matches {
-        match matches.value_of("language") {
-            Some("rust") => {
-                assert_prereqs();
+    let matches = match matches {
+        Some(matches) => matches,
+        _ => panic!("could not get matches for init")
+    };
 
-                let project_name = matches.value_of("project_name").unwrap();
+    match matches.value_of("language") {
+        Some("rust") => {
+            assert_prereqs();
 
-                let mut reg = Handlebars::new();
-                reg.register_template_string("assemblylift.toml",
-                                             templates::ASSEMBLYLIFT_TOML).unwrap();
+            let project_name = matches.value_of("project_name").unwrap();
+            fs::create_dir(path::Path::new(&format!("./{}", project_name)));
+            fs::create_dir(path::Path::new(&format!("./{}/services", project_name)));
 
-                let mut assemblylift_toml_data = Map::<String, Json>::new();
-                assemblylift_toml_data.insert("project_name".to_string(),
-                                              to_json(project_name.to_string()));
-                let assemblylift_toml_render = reg.render("assemblylift.toml",
-                                                          &assemblylift_toml_data).unwrap();
-                println!("{}", assemblylift_toml_render)
-            }
-            Some(unknown) => panic!("unsupported language: {}", unknown),
-            _ => {}
+            let canonical_project_path =
+                &fs::canonicalize(path::Path::new(&format!("./{}", project_name)))
+                    .unwrap();
+
+            write_manifest(canonical_project_path, project_name).unwrap();
         }
+        Some(unknown) => panic!("unsupported language: {}", unknown),
+        _ => {}
     }
 }
 
@@ -52,10 +58,42 @@ fn assert_prereqs() {
     }
 }
 
+fn write_to_file(path: &path::Path, contents: String) -> Result<(), io::Error> {
+    let mut file = match fs::File::create(path) {
+        Err(why) => panic!("couldn't create file {}: {}", path.display(), why.to_string()),
+        Ok(file) => file
+    };
+
+    file.write_all(contents.as_bytes())
+}
+
+fn write_manifest(canonical_project_path: &PathBuf, project_name: &str) -> Result<(), io::Error> {
+    let mut reg = Handlebars::new();
+    reg.register_template_string("assemblylift.toml",
+                                 templates::ASSEMBLYLIFT_TOML).unwrap();
+
+    let mut assemblylift_toml_data = Map::<String, Json>::new();
+    assemblylift_toml_data.insert("project_name".to_string(),
+                                  to_json(project_name.to_string()));
+    assemblylift_toml_data.insert("asml_version".to_string(), to_json(crate_version!()));
+
+    let assemblylift_toml_render = reg.render("assemblylift.toml",
+                                              &assemblylift_toml_data).unwrap();
+
+    let path_str = &format!("{}/assemblylift.toml", canonical_project_path.display());
+    let path = path::Path::new(path_str);
+    write_to_file(&path, assemblylift_toml_render);
+    println!("Wrote {}", path_str);
+
+    Ok(())
+}
+
 mod templates {
     pub(crate) static ASSEMBLYLIFT_TOML: &str =
-r"[project]
-name = {{project_name}}
-version = 0.1.0
-";
+r#"# Generated with assemblylift-cli {{asml_version}}
+
+[project]
+name = "{{project_name}}"
+version = "0.1.0"
+"#;
 }

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -1,13 +1,27 @@
 use std::process;
 
 use clap::ArgMatches;
+use handlebars::{to_json, Handlebars};
+use serde_json::value::{Map, Value as Json};
 
 pub fn init(matches: Option<&ArgMatches>) {
     if let Some(matches) = matches {
         match matches.value_of("language") {
             Some("rust") => {
                 assert_prereqs();
-                // TODO generate rust project
+
+                let project_name = matches.value_of("project_name").unwrap();
+
+                let mut reg = Handlebars::new();
+                reg.register_template_string("assemblylift.toml",
+                                             templates::ASSEMBLYLIFT_TOML).unwrap();
+
+                let mut assemblylift_toml_data = Map::<String, Json>::new();
+                assemblylift_toml_data.insert("project_name".to_string(),
+                                              to_json(project_name.to_string()));
+                let assemblylift_toml_render = reg.render("assemblylift.toml",
+                                                          &assemblylift_toml_data).unwrap();
+                println!("{}", assemblylift_toml_render)
             }
             Some(unknown) => panic!("unsupported language: {}", unknown),
             _ => {}
@@ -36,4 +50,12 @@ fn assert_prereqs() {
     if !check_prereqs() {
         panic!("missing system dependencies")
     }
+}
+
+mod templates {
+    pub(crate) static ASSEMBLYLIFT_TOML: &str =
+r"[project]
+name = {{project_name}}
+version = 0.1.0
+";
 }

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -21,14 +21,14 @@ pub fn init(matches: Option<&ArgMatches>) {
     let project_name = matches.value_of("project_name").unwrap();
 
     projectfs::initialize_project_directories(project_name,
-                                                     default_service_name,
-                                                     default_function_name).unwrap();
+                                              default_service_name,
+                                              default_function_name).unwrap();
 
     let canonical_project_path =
         &fs::canonicalize(path::Path::new(&format!("./{}", project_name)))
             .unwrap();
 
-    projectfs::write_project_manifest(canonical_project_path, project_name).unwrap();
+    projectfs::write_project_manifest(canonical_project_path, project_name, default_service_name).unwrap();
     projectfs::write_service_manifest(canonical_project_path, default_service_name).unwrap();
 
     match matches.value_of("language") {

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -1,5 +1,39 @@
+use std::process;
+
 use clap::ArgMatches;
 
 pub fn init(matches: Option<&ArgMatches>) {
-    unimplemented!("init command")
+    if let Some(matches) = matches {
+        match matches.value_of("language") {
+            Some("rust") => {
+                assert_prereqs();
+                // TODO generate rust project
+            }
+            Some(unknown) => panic!("unsupported language: {}", unknown),
+            _ => {}
+        }
+    }
+}
+
+fn check_prereqs() -> bool {
+    let cargo_version = process::Command::new("cargo")
+        .arg("--version")
+        .output();
+
+    match cargo_version {
+        Ok(version) => {
+            println!("Found Cargo: {}", String::from_utf8_lossy(&version.stdout));
+            true
+        },
+        Err(_) => {
+            println!("ERROR: missing Cargo!");
+            false
+        }
+    }
+}
+
+fn assert_prereqs() {
+    if !check_prereqs() {
+        panic!("missing system dependencies")
+    }
 }

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -1,0 +1,5 @@
+use clap::ArgMatches;
+
+pub fn init(matches: Option<&ArgMatches>) {
+    unimplemented!("init command")
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,0 +1,5 @@
+use clap::ArgMatches;
+
+pub type CommandFn = fn(Option<&ArgMatches>);
+
+pub mod init;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -29,6 +29,7 @@ fn main() {
                         .required(true)
                         .takes_value(true)
                 )
+                // TODO this is going to need an argument to specify the backend (ie aws-lambda, azure, etc)
         );
     let matches = app.get_matches();
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{crate_version, Arg, App, SubCommand};
+use clap::{crate_version, Arg, App};
 use crate::commands::init::init;
 use std::collections::HashMap;
 use crate::commands::CommandFn;
@@ -13,7 +13,15 @@ fn main() {
                 .arg(
                     Arg::with_name("language")
                         .short("l")
+                        .long("lang")
                         .default_value("rust")
+                        .takes_value(true)
+                )
+                .arg(
+                    Arg::with_name("name")
+                        .short("n")
+                        .long("name")
+                        .required(true)
                         .takes_value(true)
                 )
         );
@@ -23,7 +31,6 @@ fn main() {
     command_map.insert("init", init);
 
     match matches.subcommand() {
-        (name, matches) => command_map[name](matches),
-        _ => {}
+        (name, matches) => command_map[name](matches)
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate serde_json;
+
 use clap::{crate_version, Arg, App};
 use crate::commands::init::init;
 use std::collections::HashMap;
@@ -18,7 +21,7 @@ fn main() {
                         .takes_value(true)
                 )
                 .arg(
-                    Arg::with_name("name")
+                    Arg::with_name("project_name")
                         .short("n")
                         .long("name")
                         .required(true)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,6 +7,8 @@ use std::collections::HashMap;
 use crate::commands::CommandFn;
 
 mod commands;
+mod projectfs;
+mod templates;
 
 fn main() {
     let app = App::new("asml")

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,15 +1,29 @@
 use clap::{crate_version, Arg, App, SubCommand};
+use crate::commands::init::init;
+use std::collections::HashMap;
+use crate::commands::CommandFn;
+
+mod commands;
 
 fn main() {
     let app = App::new("asml")
         .version(crate_version!())
         .subcommand(
             App::new("init")
+                .arg(
+                    Arg::with_name("language")
+                        .short("l")
+                        .default_value("rust")
+                        .takes_value(true)
+                )
         );
     let matches = app.get_matches();
 
+    let mut command_map = HashMap::<&str, CommandFn>::new();
+    command_map.insert("init", init);
+
     match matches.subcommand() {
-        ("init", init_matches) => {}
+        (name, matches) => command_map[name](matches),
         _ => {}
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,3 +1,15 @@
+use clap::{crate_version, Arg, App, SubCommand};
+
 fn main() {
-    println!("Hello, world!");
+    let app = App::new("asml")
+        .version(crate_version!())
+        .subcommand(
+            App::new("init")
+        );
+    let matches = app.get_matches();
+
+    match matches.subcommand() {
+        ("init", init_matches) => {}
+        _ => {}
+    }
 }

--- a/cli/src/projectfs.rs
+++ b/cli/src/projectfs.rs
@@ -23,7 +23,7 @@ pub fn initialize_project_directories(project_name: &str, default_service_name: 
     Ok(())
 }
 
-pub fn write_project_manifest(canonical_project_path: &PathBuf, project_name: &str) -> Result<(), io::Error> {
+pub fn write_project_manifest(canonical_project_path: &PathBuf, project_name: &str, default_service_name: &str) -> Result<(), io::Error> {
     let file_name = "assemblylift.toml";
 
     let mut reg = Handlebars::new();
@@ -31,6 +31,7 @@ pub fn write_project_manifest(canonical_project_path: &PathBuf, project_name: &s
 
     let mut data = Map::<String, Json>::new();
     data.insert("project_name".to_string(), to_json(project_name.to_string()));
+    data.insert("default_service_name".to_string(), to_json(default_service_name.to_string()));
     data.insert("asml_version".to_string(), to_json(crate_version!()));
 
     let render = reg.render(file_name, &data).unwrap();

--- a/cli/src/projectfs.rs
+++ b/cli/src/projectfs.rs
@@ -1,0 +1,135 @@
+use std::{fs, io, path};
+use std::io::Write;
+use std::path::PathBuf;
+
+use clap::crate_version;
+use handlebars::{Handlebars, to_json};
+use serde_json::value::{Map, Value as Json};
+
+use crate::templates;
+
+pub fn initialize_project_directories(project_name: &str, default_service_name: &str, default_function_name: &str) -> Result<(), io::Error> {
+    fs::create_dir(path::Path::new(&format!("./{}", project_name)));
+    fs::create_dir(path::Path::new(&format!("./{}/services", project_name)));
+    fs::create_dir(path::Path::new(&format!("./{}/services/{}",
+                                            project_name, default_service_name)));
+    fs::create_dir(path::Path::new(&format!("./{}/services/{}/{}",
+                                            project_name, default_service_name, default_function_name)));
+    fs::create_dir(path::Path::new(&format!("./{}/services/{}/{}/src",
+                                           project_name, default_service_name, default_function_name)));
+    fs::create_dir(path::Path::new(&format!("./{}/services/{}/{}/.cargo",
+                                            project_name, default_service_name, default_function_name)));
+
+    Ok(())
+}
+
+pub fn write_project_manifest(canonical_project_path: &PathBuf, project_name: &str) -> Result<(), io::Error> {
+    let file_name = "assemblylift.toml";
+
+    let mut reg = Handlebars::new();
+    reg.register_template_string(file_name, templates::ASSEMBLYLIFT_TOML).unwrap();
+
+    let mut data = Map::<String, Json>::new();
+    data.insert("project_name".to_string(), to_json(project_name.to_string()));
+    data.insert("asml_version".to_string(), to_json(crate_version!()));
+
+    let render = reg.render(file_name, &data).unwrap();
+
+    let path_str = &format!("{}/assemblylift.toml", canonical_project_path.display());
+    let path = path::Path::new(path_str);
+    write_to_file(&path, render);
+
+    Ok(())
+}
+
+pub fn write_service_manifest(canonical_project_path: &PathBuf, service_name: &str) -> Result<(), io::Error> {
+    let file_name = "service.toml";
+
+    let mut reg = Handlebars::new();
+    reg.register_template_string(file_name, templates::SERVICE_TOML).unwrap();
+
+    let mut data = Map::<String, Json>::new();
+    data.insert("service_name".to_string(), to_json(service_name.to_string()));
+    data.insert("asml_version".to_string(), to_json(crate_version!()));
+
+    let render = reg.render(file_name, &data).unwrap();
+
+    let path_str = &format!("{}/services/{}/service.toml",
+                            canonical_project_path.display(),
+                            service_name);
+    let path = path::Path::new(path_str);
+    write_to_file(&path, render);
+
+    Ok(())
+}
+
+pub fn write_function_manifest(canonical_project_path: &PathBuf, service_name: &str, function_name: &str) -> Result<(), io::Error> {
+    let file_name = "Cargo.toml";
+
+    let mut reg = Handlebars::new();
+    reg.register_template_string(file_name, templates::FUNCTION_CARGO_TOML).unwrap();
+
+    let mut data = Map::<String, Json>::new();
+    data.insert("function_name".to_string(), to_json(function_name.to_string()));
+    data.insert("asml_version".to_string(), to_json(crate_version!()));
+
+    let render = reg.render(file_name, &data).unwrap();
+
+    let path_str = &format!("{}/services/{}/{}/Cargo.toml",
+                            canonical_project_path.display(),
+                            service_name, function_name);
+    let path = path::Path::new(path_str);
+    write_to_file(&path, render);
+
+    Ok(())
+}
+
+pub fn write_function_cargo_config(canonical_project_path: &PathBuf, service_name: &str, function_name: &str) -> Result<(), io::Error> {
+    let file_name = "config";
+
+    let mut reg = Handlebars::new();
+    reg.register_template_string(file_name, templates::FUNCTION_CARGO_CONFIG).unwrap();
+
+    let mut data = Map::<String, Json>::new();
+    data.insert("asml_version".to_string(), to_json(crate_version!()));
+
+    let render = reg.render(file_name, &data).unwrap();
+
+    let path_str = &format!("{}/services/{}/{}/.cargo/config",
+                            canonical_project_path.display(),
+                            service_name, function_name);
+    let path = path::Path::new(path_str);
+    write_to_file(&path, render);
+
+    Ok(())
+}
+
+pub fn write_function_lib(canonical_project_path: &PathBuf, service_name: &str, function_name: &str) -> Result<(), io::Error> {
+    let file_name = "lib.rs";
+
+    let mut reg = Handlebars::new();
+    reg.register_template_string(file_name, templates::FUNCTION_LIB_RS).unwrap();
+
+    let mut data = Map::<String, Json>::new();
+    data.insert("asml_version".to_string(), to_json(crate_version!()));
+
+    let render = reg.render(file_name, &data).unwrap();
+
+    let path_str = &format!("{}/services/{}/{}/src/lib.rs",
+                            canonical_project_path.display(),
+                            service_name, function_name);
+    let path = path::Path::new(path_str);
+    write_to_file(&path, render);
+
+    Ok(())
+}
+
+fn write_to_file(path: &path::Path, contents: String) -> Result<(), io::Error> {
+    let mut file = match fs::File::create(path) {
+        Err(why) => panic!("couldn't create file {}: {}", path.display(), why.to_string()),
+        Ok(file) => file
+    };
+
+    println!("📄 Wrote {}", path.display());
+    file.write_all(contents.as_bytes())
+}

--- a/cli/src/templates.rs
+++ b/cli/src/templates.rs
@@ -1,0 +1,65 @@
+pub(crate) static ASSEMBLYLIFT_TOML: &str =
+r#"# Generated with assemblylift-cli {{asml_version}}
+
+[project]
+name = "{{project_name}}"
+version = "0.1.0"
+
+[services]
+my_first_service = { name = "my_first_service" }
+"#;
+
+pub(crate) static SERVICE_TOML: &str =
+r#"# Generated with assemblylift-cli {{asml_version}}
+
+[service]
+name = "{{service_name}}"
+version = ""
+
+[api]
+name = "{{service_name}}-api"
+"#;
+
+pub(crate) static FUNCTION_CARGO_TOML: &str =
+r#"# Generated with assemblylift-cli {{asml_version}}
+
+[package]
+name = "{{function_name}}"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+direct-executor = "0.3.0"
+serde_json = "1.0.53"
+asml_core = { package = "assemblylift-core-guest", git = "https://github.com/akkoro/assemblylift", branch="research" }
+asml_core_event = { package = "assemblylift-core-event-guest", git = "https://github.com/akkoro/assemblylift", branch="research" }
+asml_awslambda = { package = "assemblylift-awslambda-guest", git = "https://github.com/akkoro/assemblylift", branch="research" }
+asml_awslambda_iomod = { package = "assemblylift-awslambda-iomod-guest", git = "https://github.com/akkoro/assemblylift", branch="research" }
+"#;
+
+pub(crate) static FUNCTION_CARGO_CONFIG: &str =
+r#"# Generated with assemblylift-cli {{asml_version}}
+
+[build]
+target = "wasm32-unknown-unknown"
+"#;
+
+pub(crate) static FUNCTION_LIB_RS: &str =
+r#"// Generated with assemblylift-cli {{asml_version}}
+
+extern crate asml_awslambda;
+
+use direct_executor;
+use asml_core::GuestCore;
+use asml_awslambda::{*, AwsLambdaClient, LambdaContext};
+
+handler!(context: LambdaContext, async {
+    let event = context.event;
+    AwsLambdaClient::console_log(format!("Read event: {:?}", event));
+
+    AwsLambdaClient::success("OK".to_string());
+});
+"#;

--- a/cli/src/templates.rs
+++ b/cli/src/templates.rs
@@ -6,7 +6,7 @@ name = "{{project_name}}"
 version = "0.1.0"
 
 [services]
-my_first_service = { name = "my_first_service" }
+default = { name = "{{default_service_name}}" }
 "#;
 
 pub(crate) static SERVICE_TOML: &str =


### PR DESCRIPTION
This adds a very basic CLI named `asml`, which currently supports only the `init` command.

`asml init -n <name>` will bootstrap a new AssemblyLift project in `$(pwd)/name`.

The tentative directory structure (so far) is as follows (assuming a Rust language template).

```
assemblylift.toml
common/
services/
  - <service>
    - service.toml
    - functions/
      - <function>
        - Cargo.toml
        - src/
        - .cargo/
      - <function>
      .
      .
  - <service>
  .
  .
```