### PR TITLE
IOmod macros & cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,7 @@ dependencies = [
  "crossbeam-utils",
  "futures",
  "lazy_static",
+ "paste",
  "rusoto_core",
  "rusoto_dynamodb",
  "serde_json",
@@ -104,8 +105,10 @@ name = "assemblylift-core"
 version = "0.1.0"
 dependencies = [
  "assemblylift-core-event",
+ "assemblylift-core-event-common",
  "crossbeam-utils",
  "lazy_static",
+ "paste",
  "serde",
  "wasmer-runtime",
  "wasmer-runtime-core",
@@ -1213,6 +1216,28 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "paste"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a229b1c58c692edcaa5b9b0948084f130f55d2dcc15b02fcc5340b2b4521476"
+dependencies = [
+ "paste-impl",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "paste-impl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e0bf239e447e67ff6d16a8bb5e4d4bd2343acf5066061c0e8e06ac5ba8ca68c"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,8 +85,10 @@ name = "assemblylift-awslambda-iomod-guest"
 version = "0.1.0"
 dependencies = [
  "assemblylift-core-event-guest",
+ "assemblylift-core-guest",
  "base64 0.12.1",
  "bytes",
+ "paste",
  "serde",
  "serde_json",
 ]
@@ -149,6 +151,9 @@ dependencies = [
 [[package]]
 name = "assemblylift-core-guest"
 version = "0.1.0"
+dependencies = [
+ "paste",
+]
 
 [[package]]
 name = "async-trait"

--- a/backends/aws-lambda/host/src/main.rs
+++ b/backends/aws-lambda/host/src/main.rs
@@ -1,33 +1,15 @@
 #[macro_use]
 extern crate lazy_static;
 
-use std::borrow::Borrow;
-use std::cell::Cell;
 use std::env;
-use std::error::Error;
-use std::ffi::c_void;
-use std::fs::{canonicalize, File};
-use std::io;
-use std::io::ErrorKind;
-use std::io::prelude::*;
-use std::str::Utf8Error;
-use std::sync::{Arc, Mutex};
-use std::sync::mpsc::sync_channel;
+use std::sync::Mutex;
 
 use crossbeam_utils::atomic::AtomicCell;
 use crossbeam_utils::thread::scope;
-use wasmer_runtime::{Array, Ctx, Export, Instance, LikeNamespace, WasmPtr};
-use wasmer_runtime::memory::MemoryView;
-use wasmer_runtime::types::{FuncSig, Type};
-use wasmer_runtime_core::backend::SigRegistry;
-use wasmer_runtime_core::export::{Context, FuncPointer};
-use wasmer_runtime_core::Func;
-use wasmer_runtime_core::typed_func::Wasm;
+use wasmer_runtime::Instance;
 
 use assemblylift_core::iomod::*;
 use assemblylift_core::WasmBufferPtr;
-use assemblylift_core_event::threader::Threader;
-use assemblylift_core_event_common::constants::EVENT_BUFFER_SIZE_BYTES;
 use runtime::AwsLambdaRuntime;
 
 mod runtime;

--- a/backends/aws-lambda/iomod/Cargo.toml
+++ b/backends/aws-lambda/iomod/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 serde_json = "1.0.53"
 futures = "0.3.4"
 lazy_static = "1.4.0"
+paste = "0.1.12"
 crossbeam-utils = "0.7.2"
 rusoto_core = { version = "0.43.0" }
 rusoto_dynamodb = { version = "0.43.0", features = ["serialize_structs", "deserialize_structs"] }

--- a/backends/aws-lambda/iomod/guest/Cargo.toml
+++ b/backends/aws-lambda/iomod/guest/Cargo.toml
@@ -11,4 +11,6 @@ serde = "1.0.106"
 serde_json = "1.0.53"
 bytes = "0.5.4"
 base64 = "0.12.1"
+paste = "0.1.12"
+assemblylift_core_guest = { package = "assemblylift-core-guest", path = "../../../../core/guest" }
 assemblylift_core_event_guest = { package = "assemblylift-core-event-guest", path = "../../../../core/event/guest" }

--- a/backends/aws-lambda/iomod/guest/src/lib.rs
+++ b/backends/aws-lambda/iomod/guest/src/lib.rs
@@ -98,4 +98,29 @@ pub mod database {
             _ => Event::<UpdateItemOutput>::new(event_id as u32)
         }
     }
+
+    #[macro_export]
+    macro_rules! val {
+        (B => $val:expr) => (
+            {
+                let mut attr = AttributeValue::default();
+                attr.b = Some($val);
+                attr
+            }
+        );
+        (S => $val:expr) => (
+            {
+                let mut attr = AttributeValue::default();
+                attr.s = Some($val.to_string());
+                attr
+            }
+        );
+        (N => $val:expr) => (
+            {
+                let mut attr = AttributeValue::default();
+                attr.n = Some($val.to_string());
+                attr
+            }
+        );
+    }
 }

--- a/backends/aws-lambda/iomod/guest/src/lib.rs
+++ b/backends/aws-lambda/iomod/guest/src/lib.rs
@@ -1,5 +1,3 @@
-use assemblylift_core_event_guest::*;
-
 pub mod structs;
 mod serialization;
 
@@ -9,95 +7,19 @@ extern {
 
 pub mod database {
     use serde_json;
+    use paste;
 
-    use assemblylift_core_event_guest::{Event, EVENT_BUFFER};
+    use assemblylift_core_guest::*;
+    use assemblylift_core_event_guest::Event;
 
-    use crate::structs::{ListTablesOutput, PutItemInput, PutItemOutput, GetItemInput, GetItemOutput, DeleteItemInput, DeleteItemOutput, UpdateItemInput, UpdateItemOutput};
+    use crate::structs::{ListTablesInput, ListTablesOutput, PutItemInput, PutItemOutput, 
+        GetItemInput, GetItemOutput, DeleteItemInput, DeleteItemOutput, UpdateItemInput, UpdateItemOutput};
 
-    pub fn aws_dynamodb_list_tables<'a>() -> Event<'a, ListTablesOutput> {
-        let event_id: i32;
-        unsafe {
-            let input_ptr: *const u8 = 0 as *const u8;
-            let name = "aws.dynamodb.list_tables";
-
-            event_id = crate::__asml_abi_invoke(EVENT_BUFFER.as_ptr(),
-                                                name.as_ptr(), name.len(),
-                                                input_ptr, 0);
-        }
-
-        match event_id {
-            -1 => panic!("unable to invoke fn"),
-            _ => Event::<ListTablesOutput>::new(event_id as u32)
-        }
-    }
-
-    pub fn aws_dynamodb_put_item<'a>(input: PutItemInput) -> Event<'a, PutItemOutput> {
-        let event_id: i32;
-        unsafe {
-            let serialized: Box<Vec<u8>> = Box::from(serde_json::to_vec(&input).unwrap());
-
-            let name = "aws.dynamodb.put_item";
-            event_id = crate::__asml_abi_invoke(EVENT_BUFFER.as_ptr(),
-                                                name.as_ptr(), name.len(),
-                                                serialized.as_ptr(), serialized.len());
-        }
-
-        match event_id {
-            -1 => panic!("unable to invoke fn"),
-            _ => Event::<PutItemOutput>::new(event_id as u32)
-        }
-    }
-
-    pub fn aws_dynamodb_get_item<'a>(input: GetItemInput) -> Event<'a, GetItemOutput> {
-        let event_id: i32;
-        unsafe {
-            let serialized: Box<Vec<u8>> = Box::from(serde_json::to_vec(&input).unwrap());
-
-            let name = "aws.dynamodb.get_item";
-            event_id = crate::__asml_abi_invoke(EVENT_BUFFER.as_ptr(),
-                                                name.as_ptr(), name.len(),
-                                                serialized.as_ptr(), serialized.len());
-        }
-
-        match event_id {
-            -1 => panic!("unable to invoke fn"),
-            _ => Event::<GetItemOutput>::new(event_id as u32)
-        }
-    }
-
-    pub fn aws_dynamodb_delete_item<'a>(input: DeleteItemInput) -> Event<'a, DeleteItemOutput> {
-        let event_id: i32;
-        unsafe {
-            let serialized: Box<Vec<u8>> = Box::from(serde_json::to_vec(&input).unwrap());
-
-            let name = "aws.dynamodb.delete_item";
-            event_id = crate::__asml_abi_invoke(EVENT_BUFFER.as_ptr(),
-                                                name.as_ptr(), name.len(),
-                                                serialized.as_ptr(), serialized.len());
-        }
-
-        match event_id {
-            -1 => panic!("unable to invoke fn"),
-            _ => Event::<DeleteItemOutput>::new(event_id as u32)
-        }
-    }
-
-    pub fn aws_dynamodb_update_item<'a>(input: UpdateItemInput) -> Event<'a, UpdateItemOutput> {
-        let event_id: i32;
-        unsafe {
-            let serialized: Box<Vec<u8>> = Box::from(serde_json::to_vec(&input).unwrap());
-
-            let name = "aws.dynamodb.update_item";
-            event_id = crate::__asml_abi_invoke(EVENT_BUFFER.as_ptr(),
-                                                name.as_ptr(), name.len(),
-                                                serialized.as_ptr(), serialized.len());
-        }
-
-        match event_id {
-            -1 => panic!("unable to invoke fn"),
-            _ => Event::<UpdateItemOutput>::new(event_id as u32)
-        }
-    }
+    call!(aws => dynamodb => list_tables, ListTablesInput => ListTablesOutput);
+    call!(aws => dynamodb => put_item, PutItemInput => PutItemOutput);
+    call!(aws => dynamodb => get_item, GetItemInput => GetItemOutput);
+    call!(aws => dynamodb => delete_item, DeleteItemInput => DeleteItemOutput);
+    call!(aws => dynamodb => update_item, UpdateItemInput => UpdateItemOutput);
 
     #[macro_export]
     macro_rules! val {

--- a/backends/aws-lambda/iomod/guest/src/structs.rs
+++ b/backends/aws-lambda/iomod/guest/src/structs.rs
@@ -173,6 +173,21 @@ pub struct GetItemOutput {
     pub item: Option<::std::collections::HashMap<String, AttributeValue>>,
 }
 
+/// <p>Represents the input of a <code>ListTables</code> operation.</p>
+
+#[derive(Default, Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct ListTablesInput {
+    /// <p>The first table name that this operation will evaluate. Use the value that was returned for <code>LastEvaluatedTableName</code> in a previous operation, so that you can obtain the next page of results.</p>
+    #[serde(rename = "ExclusiveStartTableName")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exclusive_start_table_name: Option<String>,
+
+    /// <p>A maximum number of table names to return. If this parameter is not specified, the limit is 100.</p>
+    #[serde(rename = "Limit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<i64>,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ListTablesOutput {
     #[serde(rename = "LastEvaluatedTableName")]

--- a/backends/aws-lambda/iomod/src/lib.rs
+++ b/backends/aws-lambda/iomod/src/lib.rs
@@ -2,144 +2,79 @@
 extern crate lazy_static;
 #[macro_use]
 extern crate assemblylift_core;
+extern crate paste;
 
 pub mod database {
     use std::collections::HashMap;
-    use std::future::Future;
 
     use crossbeam_utils::atomic::AtomicCell;
+    use paste;
     use rusoto_core::Region;
-    use rusoto_dynamodb::{DynamoDb, DynamoDbClient, ListTablesInput};
+    use rusoto_dynamodb::DynamoDbClient;
     use serde_json;
     use wasmer_runtime_core::vm;
 
     use assemblylift_core::iomod::{AsmlAbiFn, IoModule, ModuleRegistry};
     use assemblylift_core::WasmBufferPtr;
-    use assemblylift_core_event::threader::Threader;
-    use assemblylift_core_event_common::constants::EVENT_BUFFER_SIZE_BYTES;
 
     lazy_static! {
         static ref DYNAMODB: DynamoDbClient = DynamoDbClient::new(Region::UsEast1);
     }
 
     // aws.dynamodb.list_tables
+    call!(aws_dynamodb_list_tables =>
+        pub async fn aws_dynamodb_list_tables_impl(input: Vec<u8>) -> Vec<u8> {
+            use rusoto_dynamodb::*;
 
-    async fn __aws_dynamodb_list_tables_impl() -> Vec<u8> {
-        println!("TRACE: __aws_dynamodb_list_tables_impl");
-
-        let result = DYNAMODB.list_tables(ListTablesInput {
-            exclusive_start_table_name: None,
-            limit: None,
-        }).await.unwrap();
-
-        serde_json::to_vec(&result).unwrap()
-    }
-
-    pub fn aws_dynamodb_list_tables_impl(ctx: &mut vm::Ctx, mem: WasmBufferPtr, _input: WasmBufferPtr, _input_len: u32) -> i32 {
-        println!("TRACE: aws_dynamodb_list_tables_impl");
-        spawn_event(ctx, mem, __aws_dynamodb_list_tables_impl())
-    }
+            let deserialized = serde_json::from_slice(input.as_slice()).unwrap();
+            let result = DYNAMODB.list_tables(deserialized).await.unwrap();
+            serde_json::to_vec(&result).unwrap()
+        }
+    );
 
     // aws.dynamodb.put_item
+    call!(aws_dynamodb_put_item =>
+        pub async fn aws_dynamodb_put_item_impl(input: Vec<u8>) -> Vec<u8> {
+            use rusoto_dynamodb::*;
 
-    async fn __aws_dynamodb_put_item_impl(input: Vec<u8>) -> Vec<u8> {
-        println!("TRACE: __aws_dynamodb_put_item_impl");
-
-        let deserialized = serde_json::from_slice(input.as_slice()).unwrap();
-        let result = DYNAMODB.put_item(deserialized).await.unwrap();
-        serde_json::to_vec(&result).unwrap()
-    }
-
-    pub fn aws_dynamodb_put_item_impl(ctx: &mut vm::Ctx, mem: WasmBufferPtr, input: WasmBufferPtr, input_len: u32) -> i32 {
-        println!("TRACE: aws_dynamodb_put_item_impl");
-
-        let input_vec = wasm_buffer_as_vec(ctx, input, input_len);
-        spawn_event(ctx, mem, __aws_dynamodb_put_item_impl(input_vec))
-    }
+            let deserialized = serde_json::from_slice(input.as_slice()).unwrap();
+            let result = DYNAMODB.put_item(deserialized).await.unwrap();
+            serde_json::to_vec(&result).unwrap()
+        }
+    );
 
     // aws.dynamodb.get_item
+    call!(aws_dynamodb_get_item =>
+        pub async fn aws_dynamodb_get_item_impl(input: Vec<u8>) -> Vec<u8> {
+            use rusoto_dynamodb::*;
 
-    async fn __aws_dynamodb_get_item_impl(input: Vec<u8>) -> Vec<u8> {
-        println!("TRACE: __aws_dynamodb_get_item_impl");
-
-        let deserialized = serde_json::from_slice(input.as_slice()).unwrap();
-        let result = DYNAMODB.get_item(deserialized).await.unwrap();
-        serde_json::to_vec(&result).unwrap()
-    }
-    
-    pub fn aws_dynamodb_get_item_impl(ctx: &mut vm::Ctx, mem: WasmBufferPtr, input: WasmBufferPtr, input_len: u32) -> i32 {
-        println!("TRACE: aws_dynamodb_get_item_impl");
-
-        let input_vec = wasm_buffer_as_vec(ctx, input, input_len);
-        spawn_event(ctx, mem, __aws_dynamodb_get_item_impl(input_vec))
-    }
+            let deserialized = serde_json::from_slice(input.as_slice()).unwrap();
+            let result = DYNAMODB.get_item(deserialized).await.unwrap();
+            serde_json::to_vec(&result).unwrap()
+        }
+    );
 
     // aws.dynamodb.delete_item
+    call!(aws_dynamodb_delete_item =>
+        pub async fn aws_dynamodb_delete_item_impl(input: Vec<u8>) -> Vec<u8> {
+            use rusoto_dynamodb::*;
 
-    async fn __aws_dynamodb_delete_item_impl(input: Vec<u8>) -> Vec<u8> {
-        println!("TRACE: __aws_dynamodb_delete_item_impl");
-
-        let deserialized = serde_json::from_slice(input.as_slice()).unwrap();
-        let result = DYNAMODB.delete_item(deserialized).await.unwrap();
-        serde_json::to_vec(&result).unwrap()
-    }
-
-    pub fn aws_dynamodb_delete_item_impl(ctx: &mut vm::Ctx, mem: WasmBufferPtr, input: WasmBufferPtr, input_len: u32) -> i32 {
-        println!("TRACE: aws_dynamodb_delete_item_impl");
-
-        let input_vec = wasm_buffer_as_vec(ctx, input, input_len);
-        spawn_event(ctx, mem, __aws_dynamodb_delete_item_impl(input_vec))
-    }
+            let deserialized = serde_json::from_slice(input.as_slice()).unwrap();
+            let result = DYNAMODB.delete_item(deserialized).await.unwrap();
+            serde_json::to_vec(&result).unwrap()
+        }
+    );
 
     // aws.dynamodb.update_item
+    call!(aws_dynamodb_update_item => 
+        pub async fn aws_dynamodb_update_item_impl(input: Vec<u8>) -> Vec<u8> {
+            use rusoto_dynamodb::*;
 
-    async fn __aws_dynamodb_update_item_impl(input: Vec<u8>) -> Vec<u8> {
-        println!("TRACE: __aws_dynamodb_update_item_impl");
-
-        let deserialized = serde_json::from_slice(input.as_slice()).unwrap();
-        let result = DYNAMODB.update_item(deserialized).await.unwrap();
-        serde_json::to_vec(&result).unwrap()
-    }
-
-    pub fn aws_dynamodb_update_item_impl(ctx: &mut vm::Ctx, mem: WasmBufferPtr, input: WasmBufferPtr, input_len: u32) -> i32 {
-        println!("TRACE: aws_dynamodb_update_item_impl");
-
-        let input_vec = wasm_buffer_as_vec(ctx, input, input_len);
-        spawn_event(ctx, mem, __aws_dynamodb_update_item_impl(input_vec))
-    }
-
-    // helpers
-
-    fn wasm_buffer_as_vec(ctx: &mut vm::Ctx, input: WasmBufferPtr, input_len: u32) -> Vec<u8> {
-        let wasm_instance_memory = ctx.memory(0);
-        let input_deref: &[AtomicCell<u8>] = input
-            .deref(wasm_instance_memory, 0, input_len)
-            .unwrap();
-
-        let mut as_vec: Vec<u8> = Vec::new();
-        for (idx, b) in input_deref.iter().enumerate() {
-            as_vec.insert(idx, b.load());
+            let deserialized = serde_json::from_slice(input.as_slice()).unwrap();
+            let result = DYNAMODB.update_item(deserialized).await.unwrap();
+            serde_json::to_vec(&result).unwrap()
         }
-
-        as_vec
-    }
-
-    fn spawn_event(ctx: &mut vm::Ctx, mem: WasmBufferPtr, future: impl Future<Output=Vec<u8>> + 'static + Send) -> i32 {
-        let threader: *mut Threader = ctx.data.cast();
-        let threader_ref = unsafe { threader.as_mut().unwrap() };
-
-        let event_id = threader_ref.next_event_id().unwrap();
-        println!("DEBUG: event_id={}", event_id);
-
-        let wasm_instance_memory = ctx.memory(0);
-        let memory_writer: &[AtomicCell<u8>] = mem
-            .deref(wasm_instance_memory, 0, EVENT_BUFFER_SIZE_BYTES as u32)
-            .unwrap();
-
-        threader_ref.spawn_with_event_id(memory_writer.as_ptr(), future, event_id);
-
-        event_id as i32
-    }
+    );
 
     // iomod interface
 
@@ -150,11 +85,11 @@ pub mod database {
             register_calls!(registry, 
                 aws => {
                     dynamodb => {
-                        list_tables => aws_dynamodb_list_tables_impl,
-                        put_item => aws_dynamodb_put_item_impl,
-                        get_item => aws_dynamodb_get_item_impl,
-                        delete_item => aws_dynamodb_delete_item_impl,
-                        update_item => aws_dynamodb_update_item_impl
+                        list_tables => aws_dynamodb_list_tables,
+                        put_item => aws_dynamodb_put_item,
+                        get_item => aws_dynamodb_get_item,
+                        delete_item => aws_dynamodb_delete_item,
+                        update_item => aws_dynamodb_update_item
                     }
                 }
             );

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate serde_json;
 
 use clap::{crate_version, Arg, App};

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,6 +10,8 @@ edition = "2018"
 crossbeam-utils = "0.7.2"
 lazy_static = "1.4.0"
 serde = "1.0.106"
+paste = "0.1.12"
 wasmer-runtime = { git = "https://github.com/dotxlem/wasmer", branch="atomic_cell" }
 wasmer-runtime-core = { git = "https://github.com/dotxlem/wasmer", branch="atomic_cell" }
 assemblylift_core_event = { package = "assemblylift-core-event", path = "./event" }
+assemblylift_core_event_common = { package = "assemblylift-core-event-common", path = "./event/common" }

--- a/core/guest/Cargo.toml
+++ b/core/guest/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+paste = "0.1.12"

--- a/core/guest/src/lib.rs
+++ b/core/guest/src/lib.rs
@@ -5,3 +5,30 @@ pub trait GuestCore {
     fn console_log(message: String);
     fn success(response: String);
 }
+
+#[macro_export]
+macro_rules! call {
+    ($org:ident => $ns:ident => $name:ident, $input:ty => $output:ty) => {
+        paste::item_with_macros! {
+            pub fn [<$org _ $ns _ $name>]<'a>(input: $input) -> Event<'a, $output> {
+                use serde_json;
+                use assemblylift_core_event_guest::{Event, EVENT_BUFFER};
+
+                let event_id: i32;
+                unsafe {
+                    let serialized: Box<Vec<u8>> = Box::from(serde_json::to_vec(&input).unwrap());
+
+                    let name = "$org.$ns.$name";
+                    event_id = crate::__asml_abi_invoke(EVENT_BUFFER.as_ptr(),
+                                                        name.as_ptr(), name.len(),
+                                                        serialized.as_ptr(), serialized.len());
+                }
+
+                match event_id {
+                    -1 => panic!("unable to invoke fn $org.$ns.$name"),
+                    _ => Event::<$output>::new(event_id as u32)
+                }
+            };
+        }
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate assemblylift_core_event;
 #[macro_use]
 extern crate lazy_static;
+extern crate paste;
 
 use std::any::Any;
 use std::borrow::Borrow;

--- a/examples/hello-world/Cargo.lock
+++ b/examples/hello-world/Cargo.lock
@@ -7,6 +7,8 @@ dependencies = [
  "assemblylift-core-event-guest",
  "assemblylift-core-guest",
  "direct-executor",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -163,6 +165,7 @@ dependencies = [
  "assemblylift-core-event-guest",
  "assemblylift-core-guest",
  "direct-executor",
+ "serde_json",
 ]
 
 [[package]]

--- a/examples/hello-world/Cargo.lock
+++ b/examples/hello-world/Cargo.lock
@@ -16,8 +16,10 @@ name = "assemblylift-awslambda-iomod-guest"
 version = "0.1.0"
 dependencies = [
  "assemblylift-core-event-guest",
+ "assemblylift-core-guest",
  "base64",
  "bytes",
+ "paste",
  "serde",
  "serde_json",
 ]
@@ -43,6 +45,9 @@ dependencies = [
 [[package]]
 name = "assemblylift-core-guest"
 version = "0.1.0"
+dependencies = [
+ "paste",
+]
 
 [[package]]
 name = "base64"
@@ -185,6 +190,28 @@ name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+
+[[package]]
+name = "paste"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a229b1c58c692edcaa5b9b0948084f130f55d2dcc15b02fcc5340b2b4521476"
+dependencies = [
+ "paste-impl",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "paste-impl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e0bf239e447e67ff6d16a8bb5e4d4bd2343acf5066061c0e8e06ac5ba8ca68c"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-utils"

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 direct-executor = "0.3.0"
+serde_json = "1.0"
 core_guest = { package = "assemblylift-core-guest", path = "../../core/guest" }
 core_event_guest = { package = "assemblylift-core-event-guest", path = "../../core/event/guest" }
 guest = { package = "assemblylift-awslambda-guest", path = "../../backends/aws-lambda/guest" }

--- a/examples/hello-world/src/lib.rs
+++ b/examples/hello-world/src/lib.rs
@@ -1,6 +1,6 @@
-#[macro_use]
 extern crate guest;
 extern crate core_event_guest;
+use serde_json;
 use awsio::*;
 use guest::*;
 use core_guest::GuestCore;
@@ -8,7 +8,7 @@ use core_guest::GuestCore;
 use std::collections::HashMap;
 
 handler!(context: LambdaContext, async {
-    AwsLambdaClient::console_log(format!("Got event: {}", context.event));
+    AwsLambdaClient::console_log(format!("Got event: {:?}", context.event));
 
     AwsLambdaClient::console_log("Calling...".to_string());
 


### PR DESCRIPTION
This implements macros `call!` and `register_calls!`, which are meant to aid in the implementation of IO modules. This is the first step towards preparing the framework to be plugin-based.

There are actually two versions of `call!` -- one for the host side of the implementation, and one for the guest side.

In the host, `call!` is used to define the implementation of an `async` function which runs in the host runtime (invoked from the WASM guest).

For example, the implementation of DynamoDB `delete_item` in the host:
```
call!(aws_dynamodb_delete_item =>
    pub async fn aws_dynamodb_delete_item_impl(input: Vec<u8>) -> Vec<u8> {
        use rusoto_dynamodb::*;

        let deserialized = serde_json::from_slice(input.as_slice()).unwrap();
        let result = DYNAMODB.delete_item(deserialized).await.unwrap();
        serde_json::to_vec(&result).unwrap()
    }
);
```

And then to generate the function ` async fn aws_dynamodb_delete_item(DeleteItemInput) -> DeleteItemOutput` in the guest:
```
call!(aws => dynamodb => delete_item, DeleteItemInput => DeleteItemOutput);
```
The first argument defines the triplet `organization => namespace => name`, which is used to lookup the call in the module registry of the host. The second argument defines the input type/output type mapping.

In the host, `register_calls!` is used to register a call in the module registry, within an organization & namespace identifier. Ex:
```
register_calls!(registry, 
    aws => {
         dynamodb => {
            list_tables => aws_dynamodb_list_tables,
            put_item => aws_dynamodb_put_item,
            get_item => aws_dynamodb_get_item,
            delete_item => aws_dynamodb_delete_item,
            update_item => aws_dynamodb_update_item
        }
    }
);
```