### PR TITLE
Threader memory manager

### DIFF
--- a/.idea/dictionaries/xlem.xml
+++ b/.idea/dictionaries/xlem.xml
@@ -1,0 +1,7 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="xlem">
+    <words>
+      <w>ioid</w>
+    </words>
+  </dictionary>
+</component>

--- a/backends/aws-lambda/guest/src/lib.rs
+++ b/backends/aws-lambda/guest/src/lib.rs
@@ -53,6 +53,7 @@ macro_rules! handler {
     ($context:ident: $type:ty, $async_handler:expr) => {
         #[no_mangle]
         pub fn handler() -> i32 {
+            use direct_executor;
             use asml_awslambda::{AWS_EVENT_STRING_BUFFER, AWS_EVENT_STRING_BUFFER_SIZE};
 
             AwsLambdaClient::console_log("Started handler...".to_string());
@@ -81,7 +82,7 @@ macro_rules! handler {
                 }
             };
 
-            let $context: $type = $type { client, event };
+            let $context: $type = LambdaContext { client, event };
 
             direct_executor::run_spinning($async_handler);
 

--- a/backends/aws-lambda/host/src/wasm.rs
+++ b/backends/aws-lambda/host/src/wasm.rs
@@ -1,13 +1,13 @@
-use std::{env, io};
 use std::cell::Cell;
 use std::error::Error;
 use std::ffi::c_void;
 use std::fs::canonicalize;
 use std::io::ErrorKind;
+use std::{env, io};
 
 use wasmer_runtime::memory::MemoryView;
-use wasmer_runtime_core::Instance;
 use wasmer_runtime_core::vm::Ctx;
+use wasmer_runtime_core::Instance;
 
 use assemblylift_core::abi::{
     asml_abi_event_len, asml_abi_event_ptr, asml_abi_invoke, asml_abi_poll,

--- a/backends/aws-lambda/iomod/dynamodb/guest/src/lib.rs
+++ b/backends/aws-lambda/iomod/dynamodb/guest/src/lib.rs
@@ -5,7 +5,7 @@ export_iomod_guest!(akkoro, aws, dynamodb);
 
 use serde_json;
 
-use assemblylift_core_event_guest::Event;
+use assemblylift_core_event_guest::Io;
 
 use crate::structs::{
     DeleteItemInput, DeleteItemOutput, GetItemInput, GetItemOutput, ListTablesInput,

--- a/backends/aws-lambda/iomod/dynamodb/src/main.rs
+++ b/backends/aws-lambda/iomod/dynamodb/src/main.rs
@@ -86,7 +86,7 @@ impl iomod::Server for Iomod {
         mut results: iomod::InvokeResults,
     ) -> Promise<(), Error> {
         let mut tx = self.tx.clone();
-        
+
         Promise::from_future(async move {
             let coords = params.get().unwrap().get_coordinates().unwrap().to_owned();
             let input = params.get().unwrap().get_input().unwrap();

--- a/core/event/common/src/constants.rs
+++ b/core/event/common/src/constants.rs
@@ -1,6 +1,1 @@
-pub const MAX_EVENTS: usize = 1024;
-pub const EVENT_SIZE_BYTES: usize = 32;
-pub const EVENT_BUFFER_SIZE_BYTES: usize = MAX_EVENTS * EVENT_SIZE_BYTES;
-pub const NUM_EVENT_HANDLES: usize = MAX_EVENTS;
-
-pub type EventBuffer = [u8; EVENT_BUFFER_SIZE_BYTES];
+pub const IO_BUFFER_SIZE_BYTES: usize = 32768;

--- a/core/event/common/src/lib.rs
+++ b/core/event/common/src/lib.rs
@@ -5,7 +5,7 @@ pub mod constants;
 // TODO move this and try adding a field for `writer`
 
 #[derive(Clone, Deserialize, Serialize)]
-pub struct EventMemoryDocument {
+pub struct IoMemoryDocument {
     pub start: usize,
     pub length: usize,
 }

--- a/core/event/common/src/lib.rs
+++ b/core/event/common/src/lib.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 
 pub mod constants;
 
+// TODO move this and try adding a field for `writer`
+
 #[derive(Clone, Deserialize, Serialize)]
 pub struct EventMemoryDocument {
     pub start: usize,

--- a/core/event/guest/src/lib.rs
+++ b/core/event/guest/src/lib.rs
@@ -8,6 +8,8 @@ use std::task::{Context, Poll, Waker};
 use serde::Deserialize;
 use serde_json;
 
+use assemblylift_core_event_common::constants::IO_BUFFER_SIZE_BYTES;
+
 extern "C" {
     fn __asml_abi_poll(id: u32) -> i32;
     fn __asml_abi_event_ptr(id: u32) -> u32;
@@ -16,16 +18,12 @@ extern "C" {
     fn __asml_abi_console_log(ptr: *const u8, len: usize);
 }
 
-const MAX_EVENTS: usize = 50;
-const EVENT_SIZE_BYTES: usize = 512;
-const EVENT_BUFFER_SIZE_BYTES: usize = MAX_EVENTS * EVENT_SIZE_BYTES;
-
-// Raw buffer holding serialized Event-Future data
-pub static mut EVENT_BUFFER: [u8; EVENT_BUFFER_SIZE_BYTES] = [0; EVENT_BUFFER_SIZE_BYTES];
+// Raw buffer holding serialized IO data
+pub static mut IO_BUFFER: [u8; IO_BUFFER_SIZE_BYTES] = [0; IO_BUFFER_SIZE_BYTES];
 
 #[no_mangle]
 pub fn __asml_get_event_buffer_pointer() -> *const u8 {
-    unsafe { EVENT_BUFFER.as_ptr() }
+    unsafe { IO_BUFFER.as_ptr() }
 }
 
 fn console_log(message: String) {
@@ -33,15 +31,15 @@ fn console_log(message: String) {
 }
 
 #[derive(Clone)]
-pub struct Event<'a, R> {
+pub struct Io<'a, R> {
     pub id: u32,
     waker: Box<Option<Waker>>,
     _phantom: PhantomData<&'a R>,
 }
 
-impl<'a, R: Deserialize<'a>> Event<'_, R> {
+impl<'a, R: Deserialize<'a>> Io<'_, R> {
     pub fn new(id: u32) -> Self {
-        Event {
+        Io {
             id,
             waker: Box::new(None),
             _phantom: PhantomData,
@@ -49,7 +47,7 @@ impl<'a, R: Deserialize<'a>> Event<'_, R> {
     }
 }
 
-impl<'a, R: Deserialize<'a>> Future for Event<'_, R> {
+impl<'a, R: Deserialize<'a>> Future for Io<'_, R> {
     type Output = R;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -67,7 +65,7 @@ unsafe fn read_response<'a, R: Deserialize<'a>>(id: u32) -> Option<R> {
     let ptr = __asml_abi_event_ptr(id) as usize;
     let end = __asml_abi_event_len(id) as usize + ptr;
 
-    match serde_json::from_slice::<R>(&EVENT_BUFFER[ptr..end]) {
+    match serde_json::from_slice::<R>(&IO_BUFFER[ptr..end]) {
         Ok(response) => Some(response),
         Err(why) => {
             console_log(why.to_string());

--- a/core/event/guest/src/lib.rs
+++ b/core/event/guest/src/lib.rs
@@ -63,9 +63,6 @@ impl<'a, R: Deserialize<'a>> Future for Event<'_, R> {
     }
 }
 
-#[derive(Deserialize)]
-pub struct Test {}
-
 unsafe fn read_response<'a, R: Deserialize<'a>>(id: u32) -> Option<R> {
     let ptr = __asml_abi_event_ptr(id) as usize;
     let end = __asml_abi_event_len(id) as usize + ptr;

--- a/core/iomod/guest/src/lib.rs
+++ b/core/iomod/guest/src/lib.rs
@@ -21,19 +21,19 @@ pub mod macros {
     #[macro_export]
     macro_rules! call {
         ($name:ident, $input:ty => $output:ty) => {
-            pub fn $name<'a>(input: $input) -> Event<'a, $output> {
-                use assemblylift_core_event_guest::{Event, EVENT_BUFFER};
+            pub fn $name<'a>(input: $input) -> Io<'a, $output> {
+                use assemblylift_core_event_guest::{Io, IO_BUFFER};
                 use serde_json;
 
                 let name = std::stringify!($name);
                 let method_path =
                     format!("{}.{}.{}.{}", IOMOD_ORG, IOMOD_NAMESPACE, IOMOD_NAME, name);
 
-                let event_id: i32;
+                let ioid: i32;
                 unsafe {
                     let serialized: Box<Vec<u8>> = Box::from(serde_json::to_vec(&input).unwrap());
-                    event_id = crate::__asml_abi_invoke(
-                        EVENT_BUFFER.as_ptr(),
+                    ioid = crate::__asml_abi_invoke(
+                        IO_BUFFER.as_ptr(),
                         method_path.as_ptr(),
                         method_path.len(),
                         serialized.as_ptr(),
@@ -41,9 +41,9 @@ pub mod macros {
                     );
                 }
 
-                match event_id {
+                match ioid {
                     -1 => panic!("unable to invoke fn {}", name),
-                    _ => Event::<$output>::new(event_id as u32),
+                    _ => Io::<$output>::new(ioid as u32),
                 }
             }
         };

--- a/core/iomod/src/registry.rs
+++ b/core/iomod/src/registry.rs
@@ -5,13 +5,13 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use capnp::capability::Promise;
-use capnp_rpc::{rpc_twoparty_capnp, RpcSystem, twoparty};
+use capnp_rpc::{rpc_twoparty_capnp, twoparty, RpcSystem};
 use futures::{AsyncReadExt, FutureExt, TryFutureExt};
 use tokio::net::TcpListener;
 use tokio::sync::mpsc;
 
-use crate::Agent;
 use crate::iomod_capnp::{agent, iomod, registry};
+use crate::Agent;
 
 pub type RegistryTx = mpsc::Sender<RegistryChannelMessage>;
 pub type RegistryRx = mpsc::Receiver<RegistryChannelMessage>;
@@ -127,11 +127,17 @@ pub fn spawn_registry(mut rx: RegistryRx) -> Result<(), RegistryError> {
             let (rpc_result, rx_result) = tokio::join!(rpc_task, rx_task);
 
             if rpc_result.is_err() {
-                println!("ERROR: registry RPC task exited with error {:?}", Some(rpc_result.err()));
+                println!(
+                    "ERROR: registry RPC task exited with error {:?}",
+                    Some(rpc_result.err())
+                );
             }
 
             if rx_result.is_err() {
-                println!("ERROR: registry rx task exited with error {:?}", Some(rx_result.err()));
+                println!(
+                    "ERROR: registry rx task exited with error {:?}",
+                    Some(rx_result.err())
+                );
             }
         })
     });

--- a/core/src/abi.rs
+++ b/core/src/abi.rs
@@ -7,7 +7,7 @@ use wasmer_runtime::memory::MemoryView;
 use wasmer_runtime_core::vm;
 
 use crate::threader::Threader;
-use crate::{spawn_event, WasmBufferPtr};
+use crate::{invoke_io, WasmBufferPtr};
 
 pub type AsmlAbiFn = fn(&mut vm::Ctx, WasmBufferPtr, WasmBufferPtr, u32) -> i32;
 
@@ -25,7 +25,7 @@ pub fn asml_abi_invoke(
 ) -> i32 {
     if let Ok(method_path) = ctx_ptr_to_string(ctx, name_ptr, name_len) {
         if let Ok(input) = ctx_ptr_to_bytes(ctx, input, input_len) {
-            return spawn_event(ctx, mem, &*method_path, input);
+            return invoke_io(ctx, mem, &*method_path, input);
         }
     }
 
@@ -43,7 +43,7 @@ pub fn asml_abi_event_ptr(ctx: &mut vm::Ctx, id: u32) -> u32 {
         threader
             .as_mut()
             .unwrap()
-            .get_event_memory_document(id)
+            .get_io_memory_document(id)
             .unwrap()
             .start as u32
     }
@@ -55,7 +55,7 @@ pub fn asml_abi_event_len(ctx: &mut vm::Ctx, id: u32) -> u32 {
         threader
             .as_mut()
             .unwrap()
-            .get_event_memory_document(id)
+            .get_io_memory_document(id)
             .unwrap()
             .length as u32
     }

--- a/core/src/abi.rs
+++ b/core/src/abi.rs
@@ -28,13 +28,13 @@ pub fn asml_abi_invoke(
             return spawn_event(ctx, mem, &*method_path, input);
         }
     }
-    
+
     -1i32 // error
 }
 
 pub fn asml_abi_poll(ctx: &mut vm::Ctx, id: u32) -> i32 {
     let threader = get_threader(ctx);
-    unsafe { threader.as_mut().unwrap().is_event_ready(id) as i32 }
+    unsafe { threader.as_mut().unwrap().poll(id) as i32 }
 }
 
 pub fn asml_abi_event_ptr(ctx: &mut vm::Ctx, id: u32) -> u32 {

--- a/core/src/threader.rs
+++ b/core/src/threader.rs
@@ -74,7 +74,7 @@ impl Threader {
 
         let coords = method_path.split(".").collect::<Vec<&str>>();
         if coords.len() != 4 {
-            panic!("Malformed method path @ spawn_with_ioid") // TODO don't panic
+            panic!("Malformed method path @ Threader::invoke") // TODO don't panic
         }
 
         let iomod_coords = format!("{}.{}.{}", coords[0], coords[1], coords[2]);


### PR DESCRIPTION
This improves (hopefully) the memory manager in `Threader`.

This memory manager maps IOmod calls to allocated space in the static buffer, which is shared between the guest WASM and the runtime host. Allocation uses a simple "block allocation" scheme. The memory is sliced into N blocks of size S; the allocator looks for and reserves enough contiguous blocks to store S bytes when the IO call returns.

The "event" naming in most instances throughout the code has been replaced with "io". A future PR will rename the crates.