### PR TITLE
Implement ABI function __asml_abi_clock_time_get

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "assemblylift-awslambda-host"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "assemblylift-core",
  "assemblylift-core-io",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "assemblylift-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "assemblylift-core-io-common",
  "assemblylift-core-iomod",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "assemblylift-core-io-guest"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "assemblylift-core-io-common",
  "futures",

--- a/backends/aws-lambda/host/Cargo.toml
+++ b/backends/aws-lambda/host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assemblylift-awslambda-host"
-version = "0.2.1"
+version = "0.2.2"
 description = "AssemblyLift AWS Lambda runtime"
 authors = ["Akkoro and the AssemblyLift contributors <assemblylift@akkoro.io>"]
 edition = "2018"
@@ -24,7 +24,7 @@ reqwest = { version = "0.10.4", features = ["blocking"] }
 wasmer_runtime = { version = "0.1.1", package = "wasmer-runtime-asml-fork" }
 wasmer_runtime_core = { version = "0.1.1", package = "wasmer-runtime-core-asml-fork" }
 
-assemblylift_core = { version = "0.2.1", package = "assemblylift-core", path = "../../../core" }
+assemblylift_core = { version = "0.2.2", package = "assemblylift-core", path = "../../../core" }
 assemblylift_core_iomod = { version = "0.2.1", package = "assemblylift-core-iomod", path = "../../../core/iomod" }
 assemblylift_core_io = { version = "0.2.0", package = "assemblylift-core-io", path = "../../../core/io" }
 assemblylift_core_io_common = { version = "0.2.0", package = "assemblylift-core-io-common", path = "../../../core/io/common" }

--- a/backends/aws-lambda/host/src/wasm.rs
+++ b/backends/aws-lambda/host/src/wasm.rs
@@ -10,7 +10,7 @@ use wasmer_runtime_core::vm::Ctx;
 use wasmer_runtime_core::Instance;
 
 use assemblylift_core::abi::{
-    asml_abi_event_len, asml_abi_event_ptr, asml_abi_invoke, asml_abi_poll, get_threader,
+    asml_abi_io_len, asml_abi_io_ptr, asml_abi_invoke, asml_abi_poll, asml_abi_clock_time_get, get_threader,
 };
 use assemblylift_core::threader::Threader;
 use assemblylift_core_iomod::registry::RegistryTx;
@@ -35,8 +35,9 @@ pub fn build_instance(tx: RegistryTx) -> Result<Instance, io::Error> {
                     "__asml_abi_success" => func!(runtime_success),
                     "__asml_abi_invoke" => func!(asml_abi_invoke),
                     "__asml_abi_poll" => func!(asml_abi_poll),
-                    "__asml_abi_event_ptr" => func!(asml_abi_event_ptr),
-                    "__asml_abi_event_len" => func!(asml_abi_event_len),
+                    "__asml_abi_io_ptr" => func!(asml_abi_io_ptr),
+                    "__asml_abi_io_len" => func!(asml_abi_io_len),
+                    "__asml_abi_clock_time_get" => func!(asml_abi_clock_time_get),
                 },
             };
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assemblylift-cli"
-version = "0.2.2"
+version = "0.2.3"
 description = "AssemblyLift command line interface"
 authors = ["Akkoro and the AssemblyLift contributors <assemblylift@akkoro.io>"]
 edition = "2018"

--- a/cli/src/bom/function.rs
+++ b/cli/src/bom/function.rs
@@ -21,7 +21,7 @@ crate-type = ["cdylib", "rlib"]
 direct-executor = "0.3.0"
 serde_json = "1.0.53"
 asml_core = { version = "0.2.0", package = "assemblylift-core-guest" }
-asml_core_io = { version = "0.2.0", package = "assemblylift-core-io-guest" }
+asml_core_io = { version = "0.2.1", package = "assemblylift-core-io-guest" }
 asml_awslambda = { version = "0.2.1", package = "assemblylift-awslambda-guest" }
 
 "#;

--- a/cli/src/commands/make.rs
+++ b/cli/src/commands/make.rs
@@ -1,5 +1,3 @@
-use std::fs;
-
 use clap::ArgMatches;
 use handlebars::to_json;
 use serde_json::value::{Map, Value as Json};

--- a/cli/src/projectfs.rs
+++ b/cli/src/projectfs.rs
@@ -4,7 +4,6 @@ use std::{fs, io};
 use path_abs::{PathAbs, PathDir};
 
 use crate::bom::{manifest, DocumentSet};
-use std::borrow::Borrow;
 
 pub struct Project {
     project_path: Box<PathBuf>,

--- a/cli/src/terraform/mod.rs
+++ b/cli/src/terraform/mod.rs
@@ -23,26 +23,6 @@ provider "aws" {
     region = "{{aws_region}}"
 }
 
-resource "aws_iam_role" "lambda_iam_role" {
-    name = "asml_{{project_name}}_lambda_iam_role"
-
-    assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
-}
-
 resource "aws_lambda_layer_version" "asml_runtime_layer" {
   filename   = "${path.module}/../.asml/runtime/bootstrap.zip"
   layer_name = "assemblylift-runtime"
@@ -60,8 +40,6 @@ module "{{this.name}}" {
 module "{{this.name}}" {
   source = "./services/{{this.service}}/{{this.name}}"
 
-  lambda_role_arn   = aws_iam_role.lambda_iam_role.arn
-  lambda_role_name  = aws_iam_role.lambda_iam_role.name
   runtime_layer_arn = aws_lambda_layer_version.asml_runtime_layer.arn
   {{#if this.service_has_layer}}
   service_layer_arn = module.{{this.service}}.service_layer_arn

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assemblylift-core"
-version = "0.2.1"
+version = "0.2.2"
 description = "AssemblyLift core library"
 authors = ["Akkoro and the AssemblyLift contributors <assemblylift@akkoro.io>"]
 edition = "2018"

--- a/core/io/guest/Cargo.toml
+++ b/core/io/guest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assemblylift-core-io-guest"
-version = "0.2.0"
+version = "0.2.1"
 description = "AssemblyLift core event WASM guest library"
 authors = ["Akkoro and the AssemblyLift contributors <assemblylift@akkoro.io>"]
 edition = "2018"

--- a/core/io/guest/src/lib.rs
+++ b/core/io/guest/src/lib.rs
@@ -12,8 +12,9 @@ use assemblylift_core_io_common::constants::IO_BUFFER_SIZE_BYTES;
 
 extern "C" {
     fn __asml_abi_poll(id: u32) -> i32;
-    fn __asml_abi_event_ptr(id: u32) -> u32;
-    fn __asml_abi_event_len(id: u32) -> u32;
+    fn __asml_abi_io_ptr(id: u32) -> u32;
+    fn __asml_abi_io_len(id: u32) -> u32;
+    fn __asml_abi_clock_time_get() -> u64;
 
     fn __asml_abi_console_log(ptr: *const u8, len: usize);
 }
@@ -28,6 +29,10 @@ pub fn __asml_get_event_buffer_pointer() -> *const u8 {
 
 fn console_log(message: String) {
     unsafe { __asml_abi_console_log(message.as_ptr(), message.len()) }
+}
+
+pub fn get_time() -> u64 {
+    unsafe { __asml_abi_clock_time_get() }
 }
 
 #[derive(Clone)]
@@ -62,8 +67,8 @@ impl<'a, R: Deserialize<'a>> Future for Io<'_, R> {
 }
 
 unsafe fn read_response<'a, R: Deserialize<'a>>(id: u32) -> Option<R> {
-    let ptr = __asml_abi_event_ptr(id) as usize;
-    let end = __asml_abi_event_len(id) as usize + ptr;
+    let ptr = __asml_abi_io_ptr(id) as usize;
+    let end = __asml_abi_io_len(id) as usize + ptr;
 
     match serde_json::from_slice::<R>(&IO_BUFFER[ptr..end]) {
         Ok(response) => Some(response),

--- a/core/src/abi.rs
+++ b/core/src/abi.rs
@@ -8,6 +8,7 @@ use wasmer_runtime_core::vm;
 
 use crate::threader::Threader;
 use crate::{invoke_io, WasmBufferPtr};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 pub type AsmlAbiFn = fn(&mut vm::Ctx, WasmBufferPtr, WasmBufferPtr, u32) -> i32;
 
@@ -37,7 +38,7 @@ pub fn asml_abi_poll(ctx: &mut vm::Ctx, id: u32) -> i32 {
     unsafe { threader.as_mut().unwrap().poll(id) as i32 }
 }
 
-pub fn asml_abi_event_ptr(ctx: &mut vm::Ctx, id: u32) -> u32 {
+pub fn asml_abi_io_ptr(ctx: &mut vm::Ctx, id: u32) -> u32 {
     let threader = get_threader(ctx);
     unsafe {
         threader
@@ -49,7 +50,7 @@ pub fn asml_abi_event_ptr(ctx: &mut vm::Ctx, id: u32) -> u32 {
     }
 }
 
-pub fn asml_abi_event_len(ctx: &mut vm::Ctx, id: u32) -> u32 {
+pub fn asml_abi_io_len(ctx: &mut vm::Ctx, id: u32) -> u32 {
     let threader = get_threader(ctx);
     unsafe {
         threader
@@ -59,6 +60,14 @@ pub fn asml_abi_event_len(ctx: &mut vm::Ctx, id: u32) -> u32 {
             .unwrap()
             .length as u32
     }
+}
+
+pub fn asml_abi_clock_time_get(_ctx: &mut vm::Ctx) -> u64 {
+    let start = SystemTime::now();
+    let unix_time = start
+        .duration_since(UNIX_EPOCH)
+        .expect("time is broken");
+    unix_time.as_secs() * 1000u64
 }
 
 #[inline]


### PR DESCRIPTION
This also fixes terraform generated for Lambda IAM, such that functions no longer all use the same role.

**Breaking Change**: `__asml_abi_event_{ptr|len}` renamed `__asml_abi_io_{ptr|len}`