### PR TITLE
User-provided terraform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "assemblylift-cli"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "clap 2.33.1",
  "handlebars",
@@ -842,9 +842,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "3.0.1"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba758d094d31274eb49d15da6f326b96bf3185239a6359bf684f3d5321148900"
+checksum = "2764f9796c0ddca4b82c07f25dd2cb3db30b9a8f47940e78e1c883d9e95c3db9"
 dependencies = [
  "log",
  "pest",
@@ -1484,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "quick-error"
-version = "1.2.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+checksum = "3ac73b1112776fc109b2e61909bc46c7e1bf0d7f690ffb1676553acce16d5cda"
 
 [[package]]
 name = "quote"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assemblylift-cli"
-version = "0.2.6"
+version = "0.2.7"
 description = "AssemblyLift command line interface"
 authors = ["Akkoro and the AssemblyLift contributors <assemblylift@akkoro.io>"]
 edition = "2018"
@@ -18,7 +18,7 @@ path = "src/main.rs"
 [dependencies]
 toml = "0.5.6"
 clap = "2.33.1"
-handlebars = "3.0.1"
+handlebars = "3.5.1"
 zip = "0.5.6"
 serde = { version = "1.0.111", features = ["derive", "rc"] }
 serde_json = "1.0.53"

--- a/cli/src/terraform/mod.rs
+++ b/cli/src/terraform/mod.rs
@@ -30,6 +30,12 @@ resource "aws_lambda_layer_version" "asml_runtime_layer" {
   source_code_hash = filebase64sha256("${path.module}/../.asml/runtime/bootstrap.zip")
 }
 
+{{#if user_inject}}
+module "usermod" {
+  source = "../user_tf"
+}
+{{/if}}
+
 {{#each services}}
 module "{{this.name}}" {
   source = "./services/{{this.name}}"
@@ -126,6 +132,11 @@ pub fn write(
     data.insert("project_name".to_string(), to_json(project_name));
     data.insert("functions".to_string(), to_json(functions));
     data.insert("services".to_string(), to_json(services));
+
+    let mut usermod_path = PathBuf::from(project_path);
+    usermod_path.push("user_tf/");
+    let usermod: bool = fs::metadata(usermod_path).is_ok();
+    data.insert("user_inject".to_string(), to_json(usermod));
 
     let render = reg.render(file_name, &data).unwrap();
 


### PR DESCRIPTION
This patch updates the CLI terraform generator, adding an optional module from `user_tf` in the project root.

The purpose of this is to allow users to build their own infrastructure alongside AssemblyLift-managed infrastructure. As functionality is adopted by AssemblyLift natively, users may migrate away from custom code.