### PR TITLE
Generic event type in Lambda context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
 name = "assemblylift-awslambda-guest"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "assemblylift-core-guest",
  "assemblylift-core-io-guest",

--- a/backends/aws-lambda/guest/Cargo.toml
+++ b/backends/aws-lambda/guest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assemblylift-awslambda-guest"
-version = "0.2.2"
+version = "0.2.3"
 description = "AssemblyLift AWS Lambda WASM guest library"
 authors = ["Akkoro and the AssemblyLift contributors <assemblylift@akkoro.io>"]
 edition = "2018"


### PR DESCRIPTION
This adds a type parameter to the `LambdaContext` struct, which is a (simple) breaking change.

When using `handler!` you now specify the event struct explicitly, which with API Gateway for example looks like
```
handler!(context: LambdaContext<ApiGatewayEvent>, async {...})
``` 