### PR TITLE
Function authorizers (IAM + JWT)

### DIFF
--- a/cli/src/bom/service.rs
+++ b/cli/src/bom/service.rs
@@ -43,6 +43,15 @@ pub struct Api {
 }
 
 #[derive(Deserialize)]
+pub struct JwtAuth;
+
+#[derive(Deserialize)]
+pub struct HttpAuth {
+    pub auth_type: String,
+    pub jwt: Option<JwtAuth>,
+}
+
+#[derive(Deserialize)]
 pub struct HttpFunction {
     pub verb: String,
     pub path: String,
@@ -54,6 +63,7 @@ pub struct Function {
     pub handler_name: String,
 
     pub http: Rc<Option<HttpFunction>>,
+    pub http_auth: Option<HttpAuth>,
 }
 
 #[derive(Deserialize)]

--- a/cli/src/commands/cast.rs
+++ b/cli/src/commands/cast.rs
@@ -182,6 +182,13 @@ pub fn command(matches: Option<&ArgMatches>) {
                     Some(http) => Some(http.path.to_string()),
                     None => None,
                 },
+                auth_type: match function.http_auth {
+                    Some(auth) => match auth.auth_type.as_str() {
+                        "IAM" => "AWS_IAM".to_string(),
+                        _ => "NONE".to_string(),
+                    },
+                    None => "NONE".to_string(),
+                },
                 project_name: project.name.clone(),
             };
 

--- a/cli/src/terraform/function.rs
+++ b/cli/src/terraform/function.rs
@@ -7,6 +7,7 @@ use handlebars::{to_json, Handlebars};
 use serde::{Deserialize, Serialize};
 use serde_json::value::{Map, Value as Json};
 
+use crate::bom;
 use crate::terraform::write_to_file;
 
 pub static TERRAFORM_FUNCTION: &str = r#"# Generated with assemblylift-cli {{asml_version}}
@@ -41,12 +42,21 @@ variable "http_api_execution_arn" {
   type = string
 }
 
+variable "http_authorizer_id" {
+  type = string
+  default = ""
+}
+
 resource "aws_apigatewayv2_route" "asml_{{name}}_http_route" {
   api_id    = var.service_http_api_id
   route_key = "${var.http_verb} ${var.http_path}"
   target    = "integrations/${aws_apigatewayv2_integration.asml_{{name}}.id}"
 
   authorization_type = "{{auth_type}}"
+  {{#if auth_has_id}}
+  authorizer_id = var.http_authorizer_id
+  authorization_scopes = ["email", "openid"]
+  {{/if}}
 }
 
 resource "aws_apigatewayv2_integration" "asml_{{name}}" {
@@ -143,7 +153,9 @@ pub struct TerraformFunction {
     pub http_verb: Option<String>,
     pub http_path: Option<String>,
 
+    pub auth_name: String,
     pub auth_type: String,
+    pub auth_has_id: bool,
 
     pub project_name: String,
 }
@@ -170,6 +182,10 @@ pub fn write(project_path: &PathBuf, function: &TerraformFunction) -> Result<(),
         to_json(function.service_has_http_api),
     );
     data.insert("auth_type".to_string(), to_json(&function.auth_type));
+    data.insert(
+        "auth_has_id".to_string(), 
+        to_json(&function.auth_has_id)
+    );
 
     let render = reg.render(file_name, &data).unwrap();
 

--- a/cli/src/terraform/function.rs
+++ b/cli/src/terraform/function.rs
@@ -45,6 +45,8 @@ resource "aws_apigatewayv2_route" "asml_{{name}}_http_route" {
   api_id    = var.service_http_api_id
   route_key = "${var.http_verb} ${var.http_path}"
   target    = "integrations/${aws_apigatewayv2_integration.asml_{{name}}.id}"
+
+  authorization_type = "{{auth_type}}"
 }
 
 resource "aws_apigatewayv2_integration" "asml_{{name}}" {
@@ -141,6 +143,8 @@ pub struct TerraformFunction {
     pub http_verb: Option<String>,
     pub http_path: Option<String>,
 
+    pub auth_type: String,
+
     pub project_name: String,
 }
 
@@ -165,6 +169,7 @@ pub fn write(project_path: &PathBuf, function: &TerraformFunction) -> Result<(),
         "service_has_http_api".to_string(),
         to_json(function.service_has_http_api),
     );
+    data.insert("auth_type".to_string(), to_json(&function.auth_type));
 
     let render = reg.render(file_name, &data).unwrap();
 

--- a/cli/src/terraform/mod.rs
+++ b/cli/src/terraform/mod.rs
@@ -56,6 +56,9 @@ module "{{this.name}}" {
   http_api_execution_arn = module.{{this.service}}.http_api_execution_arn
   http_verb = "{{this.http_verb}}"
   http_path = "{{this.http_path}}"
+  {{#if this.auth_has_id}}
+  http_authorizer_id = module.{{this.service}}.{{this.auth_name}}_authorizer_id
+  {{/if}}
   {{/if}}
 }
 

--- a/cli/src/terraform/service.rs
+++ b/cli/src/terraform/service.rs
@@ -1,12 +1,15 @@
+use std::collections::HashMap;
 use std::path;
 use std::path::PathBuf;
 use std::{fs, io};
+use std::rc::Rc;
 
 use clap::crate_version;
 use handlebars::{to_json, Handlebars};
 use serde::{Deserialize, Serialize};
 use serde_json::value::{Map, Value as Json};
 
+use crate::bom;
 use crate::terraform::write_to_file;
 
 static TERRAFORM_SERVICE: &str = r#"# Generated with assemblylift-cli {{asml_version}}
@@ -35,6 +38,23 @@ resource "aws_apigatewayv2_stage" "{{name}}_default_stage" {
   auto_deploy = true
 }
 
+{{#each jwt_authorizers}}
+resource "aws_apigatewayv2_authorizer" "{{this.name}}" {
+  api_id           = aws_apigatewayv2_api.{{../name}}_http_api.id
+  authorizer_type  = "JWT"
+  identity_sources = ["$request.header.Authorization"]
+  name             = "{{this.name}}"
+
+  jwt_configuration {
+    audience = [{{#each this.audience}}"{{this}}"{{#if this.has_next}},{{/if}}{{/each}}]
+    issuer   = "{{this.issuer}}"
+  }
+}
+output "{{this.name}}_authorizer_id" {
+    value = aws_apigatewayv2_authorizer.{{this.name}}.id
+}
+{{/each}}
+
 output "http_api_id" {
   value = aws_apigatewayv2_api.{{name}}_http_api.id
 }
@@ -45,16 +65,66 @@ output "http_api_execution_arn" {
 {{/if}}
 "#;
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct TerraformService {
     pub name: String,
     pub has_layer: bool,
     pub has_http_api: bool,
-
-    pub project_name: String,
+    pub jwt_authorizers: Vec<JwtAuth>,
 }
 
-pub fn write(project_path: &PathBuf, service: TerraformService) -> Result<(), io::Error> {
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct JwtAuth {
+    pub name: String,
+    pub audience: Vec<String>,
+    pub issuer: String,
+    pub has_next: bool,
+}
+
+impl From<bom::service::Manifest> for TerraformService {
+    fn from(manifest: bom::service::Manifest) -> Self {
+        let service_name = manifest.service.name.clone();
+        let manifest_authorizers = manifest.api.authorizers.clone();
+        let authorizers = manifest_authorizers.as_ref();
+
+        Self {
+            name: service_name.clone(),
+            has_layer: manifest.iomod.is_some(),
+            has_http_api: manifest
+                .api
+                .functions
+                .values()
+                .any(|f| f.http.is_some()),
+            jwt_authorizers: match authorizers.as_ref() {
+                Some(auths) => auths.into_iter()
+                    .filter(|(_,v)| v.auth_type.eq("JWT"))
+                    .enumerate()
+                    .map(|(idx, (k,v))| {
+                        JwtAuth { 
+                            name: String::from(k), 
+                            audience: v.audience
+                                .clone()
+                                .as_ref()
+                                .as_ref()
+                                .unwrap()
+                                .to_vec(), 
+                            issuer: v.issuer
+                                .clone()
+                                .as_ref()
+                                .as_ref()
+                                .unwrap()
+                                .to_string(),
+                            has_next: (idx + 1) < auths.keys().len()
+                        }
+                    })
+                    .collect(),
+                None => Vec::new(),
+            },
+        }
+    }
+}
+
+pub fn write(project_path: &PathBuf, project_name: String, service: TerraformService) -> Result<(), io::Error> {
     let file_name = "service.tf";
 
     let mut reg = Handlebars::new();
@@ -63,10 +133,11 @@ pub fn write(project_path: &PathBuf, service: TerraformService) -> Result<(), io
 
     let mut data = Map::<String, Json>::new();
     data.insert("asml_version".to_string(), to_json(crate_version!()));
-    data.insert("project_name".to_string(), to_json(&service.project_name));
+    data.insert("project_name".to_string(), to_json(project_name));
     data.insert("name".to_string(), to_json(&service.name));
     data.insert("has_layer".to_string(), to_json(service.has_layer));
     data.insert("has_http_api".to_string(), to_json(service.has_http_api));
+    data.insert("jwt_authorizers".to_string(), to_json(service.jwt_authorizers));
 
     let render = reg.render(file_name, &data).unwrap();
 


### PR DESCRIPTION
This PR adds support for defining function authorizers inside services. These authorizers map to API Gateway authorizers under the hood. Currently IAM and JWT authorizers are supported.

Authorizers are defined per-service, and can be referenced by multiple functions within a service.

IAM auth example; service.toml
```
[api.functions.get-object]
name = "get-object"
handler_name = "handler"
http = { verb = "GET", path = "/object/{key+}" }
authorizer_id = "iam"

[api.authorizers.iam]
auth_type = "AWS_IAM"
```

JWT auth example; service.toml
```
[api.functions.new-iomod]
name = "new-iomod"
handler_name = "handler"
http = { verb = "POST", path = "/iomod" }
authorizer_id = "cognito-jwt" # authorizer_id accepts the toml id of the authorizer

[api.authorizers.cognito-jwt] # cognito-jwt is the toml id
auth_type = "JWT"
audience = ["CLIENT_IDXXXXXXX"]
issuer = "https://cognito-idp.us-east-1.amazonaws.com/EXAMPLEXXXXXX"
```