### PR TITLE
Provider init

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,8 @@ jobs:
     - name: 'Build Image'
       run: docker build -t assemblylift/asml-lambda-default . --file docker/asml-lambda-default
     - name: 'Copy Artifacts'
-      run: docker run --rm --entrypoint cat assemblylift/asml-lambda-default /usr/src/assemblylift/target/release/bootstrap > $HOME/bootstrap && chmod 777 $HOME/bootstrap
+      run: docker run --rm --entrypoint cat assemblylift/asml-lambda-default /usr/src/assemblylift/target/release/bootstrap > $HOME/bootstrap && chmod 777 $HOME/bootstrap && zip $HOME/bootstrap.zip bootstrap
     - name: 'Get Version'
       run: echo "ASML_VERSION=$(docker run --rm assemblylift/asml-lambda-default)" >> $GITHUB_ENV 
     - name: 'Upload to S3 @ akkoro-public'
-      run: aws s3 cp $HOME/bootstrap s3://public.assemblylift.akkoro.io/runtime/$ASML_VERSION/aws-lambda/bootstrap
+      run: aws s3 cp $HOME/bootstrap.zip s3://public.assemblylift.akkoro.io/runtime/$ASML_VERSION/aws-lambda/bootstrap.zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     - name: 'Build Image'
       run: docker build -t assemblylift/asml-lambda-default . --file docker/asml-lambda-default
     - name: 'Copy Artifacts'
-      run: docker run --rm --entrypoint cat assemblylift/asml-lambda-default /usr/src/assemblylift/target/release/bootstrap > $HOME/bootstrap && chmod 777 $HOME/bootstrap && zip $HOME/bootstrap.zip bootstrap
+      run: docker run --rm --entrypoint cat assemblylift/asml-lambda-default /usr/src/assemblylift/target/release/bootstrap > $HOME/bootstrap && chmod 777 $HOME/bootstrap && zip $HOME/bootstrap.zip $HOME/bootstrap
     - name: 'Get Version'
       run: echo "ASML_VERSION=$(docker run --rm assemblylift/asml-lambda-default)" >> $GITHUB_ENV 
     - name: 'Upload to S3 @ akkoro-public'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,4 +27,4 @@ jobs:
     - name: 'Get Version'
       run: echo "ASML_VERSION=$(docker run --rm assemblylift/asml-lambda-default)" >> $GITHUB_ENV 
     - name: 'Upload to S3 @ akkoro-public'
-      run: aws s3 cp $HOME/bootstrap.zip s3://public.assemblylift.akkoro.io/runtime/$ASML_VERSION/aws-lambda/bootstrap.zip
+      run: aws s3 cp $HOME/bootstrap.zip s3://public.assemblylift.akkoro.io/runtime/$ASML_VERSION/aws-lambda/bootstrap.zip --acl public-read

--- a/cli/src/commands/cast.rs
+++ b/cli/src/commands/cast.rs
@@ -18,7 +18,6 @@ use crate::projectfs::Project;
 use crate::terraform;
 
 pub fn command(matches: Option<&ArgMatches>) {
-    use std::io::Read;
     use std::rc::Rc;
 
     let _matches = match matches {
@@ -34,23 +33,7 @@ pub fn command(matches: Option<&ArgMatches>) {
     let asml_manifest = toml::asml::Manifest::read(&manifest_path).unwrap();
     let project = Rc::new(Project::new(asml_manifest.project.name.clone(), Some(cwd)));
 
-    // Download the latest runtime binary
-    // TODO this needs to be triggerd by use in a Provider
-    let runtime_url = &*format!(
-        "http://runtime.assemblylift.akkoro.io/aws-lambda/{}/bootstrap.zip",
-//        clap::crate_version!(),
-    "xlem",
-    );
-    let mut response = reqwest::blocking::get(runtime_url).unwrap();
-    if !response.status().is_success() {
-        panic!("unable to fetch asml runtime from {}", runtime_url);
-    }
-    let mut response_buffer = Vec::new();
-    response.read_to_end(&mut response_buffer).unwrap();
-
-    fs::create_dir_all("./.asml/runtime").unwrap();
-    fs::write("./.asml/runtime/bootstrap.zip", response_buffer).unwrap();
-
+    // Fetch the latest terraform binary to the project directory
     terraform::fetch(&*project.dir());
 
     let ctx = asml::Context::from_project(project.clone(), asml_manifest)

--- a/cli/src/providers/mod.rs
+++ b/cli/src/providers/mod.rs
@@ -32,6 +32,7 @@ pub type Options = StringMap<String>;
 pub trait Provider {
     fn name(&self) -> String;
 
+    fn init(&self) -> Result<(), ProviderError>;
     fn transform(&self, ctx: Rc<asml::Context>, name: String) -> Result<Box<dyn Artifact>, ProviderError>;
 
     fn options(&self) -> Options;
@@ -90,6 +91,10 @@ impl RootProvider<'_> {
 impl<'a> Provider for RootProvider<'a> {
     fn name(&self) -> String {
         String::from("root")
+    }
+
+    fn init(&self) -> Result<(), ProviderError> {
+        Ok(())
     }
 
     fn transform(&self, ctx: Rc<asml::Context>, _name: String) -> Result<Box<dyn Artifact>, ProviderError> {

--- a/cli/src/transpiler/hcl.rs
+++ b/cli/src/transpiler/hcl.rs
@@ -90,7 +90,7 @@ pub mod service {
 
         fn cast(&mut self) -> Result<String, ArtifactError> {
             let service_name = self.name.clone();
-            let mut content = format!("# Begin service `{}`\r\n", service_name.clone());
+            let mut content = format!("# Begin service `{}`\n", service_name.clone());
 
             match self.ctx.services.iter().find(|&s| *s.name == self.name.clone()) {
                 Some(service) => {
@@ -99,6 +99,9 @@ pub mod service {
                     let provider_name = service.provider.clone();
                     let service_provider = SERVICE_PROVIDERS.get(&provider_name)
                         .expect(&format!("could not find service provider named {}", provider_name));
+
+                    service_provider.init()
+                        .expect("unable to initialize service provider");
 
                     let service_artifact = service_provider.transform(self.ctx.clone(), service_name.clone())
                         .expect("unexpected error transforming service");


### PR DESCRIPTION
This adds `fn init()` to the `Provider` trait, intended to be used for fetching any resources needed. 
The lambda service provider now uses `init` to download bootstrap.zip (moved from the top of `cast`).