### PR TITLE
Paged IO memory buffer

### DIFF
--- a/backends/aws-lambda/host/src/main.rs
+++ b/backends/aws-lambda/host/src/main.rs
@@ -8,6 +8,7 @@ use clap::crate_version;
 use once_cell::sync::Lazy;
 use tokio::sync::mpsc;
 
+use assemblylift_core::buffers::PagedBuffer;
 use assemblylift_core::threader::Threader;
 use assemblylift_core_iomod::registry;
 use runtime::AwsLambdaRuntime;
@@ -58,7 +59,7 @@ async fn main() {
                     ref_cell.replace(event.request_id.clone());
                 }
 
-                env.clone().host_input_buffer.clone().lock().unwrap().set_buffer(event.event_body.into_bytes());
+                env.clone().host_input_buffer.clone().lock().unwrap().initialize(event.event_body.into_bytes());
 
                 let instance = instance.clone();
                 tokio::task::spawn_local(async move {

--- a/backends/aws-lambda/host/src/main.rs
+++ b/backends/aws-lambda/host/src/main.rs
@@ -8,7 +8,7 @@ use clap::crate_version;
 use once_cell::sync::Lazy;
 use tokio::sync::mpsc;
 
-use assemblylift_core::buffers::PagedBuffer;
+use assemblylift_core::buffers::LinearBuffer;
 use assemblylift_core::threader::Threader;
 use assemblylift_core_iomod::registry;
 use runtime::AwsLambdaRuntime;

--- a/backends/aws-lambda/host/src/wasm.rs
+++ b/backends/aws-lambda/host/src/wasm.rs
@@ -9,7 +9,7 @@ use wasmer::{Function, imports, Instance, InstantiationError, MemoryView, Store}
 //use wasmer_engine_native::Native;
 use wasmer_engine_jit::JIT;
 
-use assemblylift_core::abi::{asml_abi_clock_time_get, asml_abi_input_length_get, asml_abi_input_next, asml_abi_input_start, asml_abi_invoke, asml_abi_io_len, asml_abi_io_ptr, asml_abi_poll, asml_abi_z85_decode, asml_abi_z85_encode};
+use assemblylift_core::abi::{asml_abi_clock_time_get, asml_abi_input_length_get, asml_abi_input_next, asml_abi_input_start, asml_abi_invoke, asml_abi_io_len, asml_abi_io_load, asml_abi_io_next, asml_abi_io_poll, asml_abi_z85_decode, asml_abi_z85_encode};
 use assemblylift_core::buffers::FunctionInputBuffer;
 use assemblylift_core::threader::{Threader, ThreaderEnv};
 use assemblylift_core_iomod::registry::RegistryTx;
@@ -42,9 +42,11 @@ pub fn build_instance(tx: RegistryTx) -> Result<(Instance, ThreaderEnv), Instant
             "__asml_abi_console_log" => Function::new_native_with_env(&store, env.clone(), runtime_console_log),
             "__asml_abi_success" => Function::new_native_with_env(&store, env.clone(), runtime_success),
             "__asml_abi_invoke" => Function::new_native_with_env(&store, env.clone(), asml_abi_invoke),
-            "__asml_abi_poll" => Function::new_native_with_env(&store, env.clone(), asml_abi_poll),
-            "__asml_abi_io_ptr" => Function::new_native_with_env(&store, env.clone(), asml_abi_io_ptr),
+            "__asml_abi_io_poll" => Function::new_native_with_env(&store, env.clone(), asml_abi_io_poll),
+//            "__asml_abi_io_ptr" => Function::new_native_with_env(&store, env.clone(), asml_abi_io_ptr),
             "__asml_abi_io_len" => Function::new_native_with_env(&store, env.clone(), asml_abi_io_len),
+            "__asml_abi_io_load" => Function::new_native_with_env(&store, env.clone(), asml_abi_io_load),
+            "__asml_abi_io_next" => Function::new_native_with_env(&store, env.clone(), asml_abi_io_next),
             "__asml_abi_clock_time_get" => Function::new_native_with_env(&store, env.clone(), asml_abi_clock_time_get),
             "__asml_abi_input_start" => Function::new_native_with_env(&store, env.clone(), asml_abi_input_start),
             "__asml_abi_input_next" => Function::new_native_with_env(&store, env.clone(), asml_abi_input_next),

--- a/backends/aws-lambda/host/src/wasm.rs
+++ b/backends/aws-lambda/host/src/wasm.rs
@@ -33,6 +33,7 @@ pub fn build_instance(tx: RegistryTx) -> Result<(Instance, ThreaderEnv), Instant
         threader: ManuallyDrop::new(Arc::new(Mutex::new(Threader::new(tx)))),
         memory: Default::default(),
         get_function_input_buffer: Default::default(),
+        get_io_buffer: Default::default(),
         host_input_buffer: Arc::new(Mutex::new(FunctionInputBuffer::new())),
     };
 

--- a/core/io/common/src/lib.rs
+++ b/core/io/common/src/lib.rs
@@ -1,11 +1,1 @@
-use serde::{Deserialize, Serialize};
-
 pub mod constants;
-
-// TODO move this and try adding a field for `writer`
-
-#[derive(Clone, Deserialize, Serialize)]
-pub struct IoMemoryDocument {
-    pub start: usize,
-    pub length: usize,
-}

--- a/core/io/guest/src/lib.rs
+++ b/core/io/guest/src/lib.rs
@@ -33,6 +33,11 @@ extern "C" {
 // Raw buffer holding serialized IO data
 pub static mut IO_BUFFER: [u8; IO_BUFFER_SIZE_BYTES] = [0; IO_BUFFER_SIZE_BYTES];
 
+#[no_mangle]
+pub fn __asml_guest_get_io_buffer_pointer() -> *const u8 {
+    unsafe { IO_BUFFER.as_ptr() }
+}
+
 fn console_log(message: String) {
     unsafe { __asml_abi_console_log(message.as_ptr(), message.len()) }
 }

--- a/core/io/guest/src/lib.rs
+++ b/core/io/guest/src/lib.rs
@@ -1,18 +1,19 @@
 use std::future::Future;
+use std::io::BufReader;
 use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll, Waker};
 
-use serde::Deserialize;
-use serde_json;
+use serde::{Deserialize, de::DeserializeOwned};
 
 use assemblylift_core_io_common::constants::{FUNCTION_INPUT_BUFFER_SIZE, IO_BUFFER_SIZE_BYTES};
 
 extern "C" {
     // IO
-    fn __asml_abi_poll(id: u32) -> i32; // TODO rename __asml_abi_io_poll for consistency in prefixing
-    fn __asml_abi_io_ptr(id: u32) -> u32;
+    fn __asml_abi_io_poll(id: u32) -> i32;
     fn __asml_abi_io_len(id: u32) -> u32;
+    fn __asml_abi_io_load(id: u32) -> i32;
+    fn __asml_abi_io_next() -> i32;
 
     // System clock
     fn __asml_abi_clock_time_get() -> u64;
@@ -46,6 +47,39 @@ pub fn get_time() -> u64 {
     unsafe { __asml_abi_clock_time_get() }
 }
 
+pub struct IoDocument {
+    bytes_read: usize,
+    pages_read: usize,
+    length: usize,
+}
+
+impl IoDocument {
+    pub fn new(ioid: u32) -> Self {
+        unsafe { __asml_abi_io_load(ioid) };
+        Self {
+            bytes_read: 0,
+            pages_read: 0,
+            length: unsafe { __asml_abi_io_len(ioid) } as usize,
+        }
+    }
+}
+
+impl std::io::Read for IoDocument {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, std::io::Error> {
+        if self.bytes_read < self.length {
+            buf[self.bytes_read] = unsafe { 
+                IO_BUFFER[self.bytes_read - (self.pages_read * IO_BUFFER_SIZE_BYTES)]
+            };
+        }
+        self.bytes_read += 1;
+        if self.bytes_read == IO_BUFFER_SIZE_BYTES {
+            unsafe { __asml_abi_io_next() };
+            self.pages_read += 1;
+        }
+        Ok(1)
+    }
+}
+
 #[derive(Clone)]
 pub struct Io<'a, R> {
     pub id: u32,
@@ -63,12 +97,15 @@ impl<'a, R: Deserialize<'a>> Io<'_, R> {
     }
 }
 
-impl<'a, R: Deserialize<'a>> Future for Io<'_, R> {
+impl<'a, R> Future for Io<'_, R> 
+where
+    R: DeserializeOwned,
+{
     type Output = R;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        match unsafe { __asml_abi_poll(self.id) } {
-            1 => Poll::Ready(unsafe { read_response::<Self::Output>(self.id).unwrap() }),
+        match unsafe { __asml_abi_io_poll(self.id) } {
+            1 => Poll::Ready(read_response::<Self::Output>(self.id).unwrap()),
             _ => {
                 self.waker = Box::new(Some(cx.waker().clone()));
                 Poll::Pending
@@ -77,11 +114,12 @@ impl<'a, R: Deserialize<'a>> Future for Io<'_, R> {
     }
 }
 
-unsafe fn read_response<'a, R: Deserialize<'a>>(id: u32) -> Option<R> {
-    let ptr = __asml_abi_io_ptr(id) as usize;
-    let end = __asml_abi_io_len(id) as usize + ptr;
-
-    match serde_json::from_slice::<R>(&IO_BUFFER[ptr..end]) {
+fn read_response<'a, T>(id: u32) -> Option<T>
+where
+    T: DeserializeOwned,
+{
+    let doc = BufReader::new(IoDocument::new(id));
+    match serde_json::from_reader::<BufReader<IoDocument>, T>(doc) {
         Ok(response) => Some(response),
         Err(why) => {
             console_log(format!("[ERROR] {}", why.to_string()));

--- a/core/src/abi.rs
+++ b/core/src/abi.rs
@@ -4,10 +4,10 @@ use std::io;
 use std::io::ErrorKind;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crossbeam_utils::atomic::AtomicCell;
 use wasmer::{MemoryView, WasmPtr, Array};
 
 use crate::{invoke_io, WasmBufferPtr};
+use crate::buffers::PagedBuffer;
 use crate::threader::ThreaderEnv;
 
 pub type AsmlAbiFn = fn(&ThreaderEnv, WasmBufferPtr, WasmBufferPtr, u32) -> i32;
@@ -74,7 +74,7 @@ pub fn asml_abi_input_start(env: &ThreaderEnv) -> i32 {
         .clone()
         .lock()
         .unwrap()
-        .start(env)
+        .first(env)
 }
 
 pub fn asml_abi_input_next(env: &ThreaderEnv) -> i32 {

--- a/core/src/abi.rs
+++ b/core/src/abi.rs
@@ -7,7 +7,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use wasmer::{MemoryView, WasmPtr, Array};
 
 use crate::{invoke_io, WasmBufferPtr};
-use crate::buffers::PagedBuffer;
+use crate::buffers::{LinearBuffer, PagedBuffer};
 use crate::threader::ThreaderEnv;
 
 pub type AsmlAbiFn = fn(&ThreaderEnv, WasmBufferPtr, WasmBufferPtr, u32) -> i32;
@@ -18,7 +18,7 @@ fn to_io_error<E: Error>(err: E) -> io::Error {
 
 pub fn asml_abi_invoke(
     env: &ThreaderEnv,
-    mem: WasmBufferPtr,
+//    mem: WasmBufferPtr,
     name_ptr: u32,
     name_len: u32,
     input: u32,
@@ -26,7 +26,7 @@ pub fn asml_abi_invoke(
 ) -> i32 {
     if let Ok(method_path) = env_ptr_to_string(env, name_ptr, name_len) {
         if let Ok(input) = env_ptr_to_bytes(env, input, input_len) {
-            return invoke_io(env, mem, &*method_path, input);
+            return invoke_io(env, &*method_path, input);
         }
     }
 

--- a/core/src/abi.rs
+++ b/core/src/abi.rs
@@ -7,7 +7,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use wasmer::{MemoryView, WasmPtr, Array};
 
 use crate::{invoke_io, WasmBufferPtr};
-use crate::buffers::{LinearBuffer, PagedBuffer};
+use crate::buffers::{LinearBuffer, PagedWasmBuffer};
 use crate::threader::ThreaderEnv;
 
 pub type AsmlAbiFn = fn(&ThreaderEnv, WasmBufferPtr, WasmBufferPtr, u32) -> i32;
@@ -18,7 +18,6 @@ fn to_io_error<E: Error>(err: E) -> io::Error {
 
 pub fn asml_abi_invoke(
     env: &ThreaderEnv,
-//    mem: WasmBufferPtr,
     name_ptr: u32,
     name_len: u32,
     input: u32,
@@ -33,7 +32,7 @@ pub fn asml_abi_invoke(
     -1i32 // error
 }
 
-pub fn asml_abi_poll(env: &ThreaderEnv, id: u32) -> i32 {
+pub fn asml_abi_io_poll(env: &ThreaderEnv, id: u32) -> i32 {
     env.threader
         .clone()
         .lock()
@@ -41,15 +40,15 @@ pub fn asml_abi_poll(env: &ThreaderEnv, id: u32) -> i32 {
         .poll(id) as i32
 }
 
-pub fn asml_abi_io_ptr(env: &ThreaderEnv, id: u32) -> u32 {
-    env.threader
-        .clone()
-        .lock()
-        .unwrap()
-        .get_io_memory_document(id)
-        .unwrap()
-        .start as u32
-}
+//pub fn asml_abi_io_ptr(env: &ThreaderEnv, id: u32) -> u32 {
+//    env.threader
+//        .clone()
+//        .lock()
+//        .unwrap()
+//        .get_io_memory_document(id)
+//        .unwrap()
+//        .start as u32
+//}
 
 pub fn asml_abi_io_len(env: &ThreaderEnv, id: u32) -> u32 {
     env.threader
@@ -59,6 +58,28 @@ pub fn asml_abi_io_len(env: &ThreaderEnv, id: u32) -> u32 {
         .get_io_memory_document(id)
         .unwrap()
         .length as u32
+}
+
+pub fn asml_abi_io_load(env: &ThreaderEnv, id: u32) -> i32 {
+    match env.threader
+        .lock()
+        .unwrap()
+        .document_load(env, id)
+    {
+        Ok(_) => 0,
+        Err(_) => -1,
+    }
+}
+
+pub fn asml_abi_io_next(env: &ThreaderEnv) -> i32 {
+    match env.threader
+        .lock()
+        .unwrap()
+        .document_next(env)
+    {
+        Ok(_) => 0,
+        Err(_) => -1,
+    }
 }
 
 pub fn asml_abi_clock_time_get(_env: &ThreaderEnv) -> u64 {
@@ -74,7 +95,7 @@ pub fn asml_abi_input_start(env: &ThreaderEnv) -> i32 {
         .clone()
         .lock()
         .unwrap()
-        .first(env)
+        .first(env, None)
 }
 
 pub fn asml_abi_input_next(env: &ThreaderEnv) -> i32 {
@@ -118,7 +139,6 @@ pub fn asml_abi_z85_decode(env: &ThreaderEnv, ptr: u32, len: u32, out_ptr: WasmP
     -1i32
 }
 
-#[inline]
 fn env_ptr_to_string(env: &ThreaderEnv, ptr: u32, len: u32) -> Result<String, io::Error> {
     let mem = env.memory_ref().unwrap();
     let view: MemoryView<u8> = mem.view();
@@ -148,7 +168,6 @@ fn write_bytes_to_ptr(env: &ThreaderEnv, s: Vec<u8>, ptr: WasmPtr<u8, Array>) ->
     Ok(())
 }
 
-#[inline]
 fn env_ptr_to_bytes(env: &ThreaderEnv, ptr: u32, len: u32) -> Result<Vec<u8>, io::Error> {
     let mem = env.memory_ref().unwrap();
     let view: MemoryView<u8> = mem.view();

--- a/core/src/buffers.rs
+++ b/core/src/buffers.rs
@@ -1,56 +1,29 @@
-use std::sync::{Arc, Mutex};
 use crossbeam_utils::atomic::AtomicCell;
-use assemblylift_core_io_common::constants::FUNCTION_INPUT_BUFFER_SIZE;
+use assemblylift_core_io_common::constants::{FUNCTION_INPUT_BUFFER_SIZE, IO_BUFFER_SIZE_BYTES};
 
 use crate::threader::ThreaderEnv;
 
+pub trait PagedBuffer {
+    fn initialize(&mut self, buffer: Vec<u8>);
+    fn first(&mut self, env: &ThreaderEnv) -> i32;
+    fn next(&mut self, env: &ThreaderEnv) -> i32;
+    fn len(&self) -> usize;
+}
+
 pub struct FunctionInputBuffer {
     buffer: Vec<u8>,
-    buffer_idx: usize,
+    page_idx: usize,
 }
 
 impl FunctionInputBuffer {
     pub fn new() -> Self {
         Self {
             buffer: Vec::new(),
-            buffer_idx: 0usize,
+            page_idx: 0usize,
         }
     }
 
-    pub fn set_buffer(&mut self, buffer: Vec<u8>) {
-        self.buffer = buffer;
-        println!("DEBUG: set_buffer len={}", self.buffer.len());
-    }
-
-    pub fn start(&mut self, env: &ThreaderEnv) -> i32 {
-        let end: usize = match self.buffer.len() < FUNCTION_INPUT_BUFFER_SIZE {
-            true => self.buffer.len(),
-            false => FUNCTION_INPUT_BUFFER_SIZE,
-        };
-        self.write_wasm_buffer(
-            env,
-            &self.buffer[0..end],
-        );
-        self.buffer_idx = 0usize;
-        0
-    }
-
-    pub fn next(&mut self, env: &ThreaderEnv) -> i32 {
-        if self.buffer.len() > FUNCTION_INPUT_BUFFER_SIZE {
-            self.buffer_idx += 1;
-            self.write_wasm_buffer(
-                env,
-                &self.buffer[FUNCTION_INPUT_BUFFER_SIZE * self.buffer_idx
-                    ..std::cmp::min(FUNCTION_INPUT_BUFFER_SIZE * (self.buffer_idx + 1), self.buffer.len())],
-            );
-        }
-        0
-    }
-
-    pub fn len(&self) -> usize {
-        self.buffer.len()
-    }
-
+    // TODO should this be here or outside as a pub fn
     fn write_wasm_buffer(&self, env: &ThreaderEnv, input: &[u8]) {
         let wasm_memory = env.memory_ref().unwrap();
         let input_buffer = env
@@ -73,3 +46,108 @@ impl FunctionInputBuffer {
     }
 }
 
+impl PagedBuffer for FunctionInputBuffer {
+    fn initialize(&mut self, buffer: Vec<u8>) {
+        self.buffer = buffer;
+        println!("DEBUG: FunctionInputBuffer len={}", self.buffer.len());
+    }
+
+    fn first(&mut self, env: &ThreaderEnv) -> i32 {
+        let end: usize = match self.buffer.len() < FUNCTION_INPUT_BUFFER_SIZE {
+            true => self.buffer.len(),
+            false => FUNCTION_INPUT_BUFFER_SIZE,
+        };
+        self.write_wasm_buffer(
+            env,
+            &self.buffer[0..end],
+        );
+        self.page_idx = 0usize;
+        0
+    }
+
+    fn next(&mut self, env: &ThreaderEnv) -> i32 {
+        if self.buffer.len() > FUNCTION_INPUT_BUFFER_SIZE {
+            self.page_idx += 1;
+            self.write_wasm_buffer(
+                env,
+                &self.buffer[FUNCTION_INPUT_BUFFER_SIZE * self.page_idx
+                    ..std::cmp::min(FUNCTION_INPUT_BUFFER_SIZE * (self.page_idx + 1), self.buffer.len())],
+            );
+        }
+        0
+    }
+
+    fn len(&self) -> usize {
+        self.buffer.len()
+    }
+}
+
+pub struct IoBuffer {
+    buffer: Vec<u8>,
+    page_idx: usize,
+}
+
+impl IoBuffer {
+    pub fn new() -> Self {
+        Self {
+            buffer: Vec::new(),
+            page_idx: 0usize,
+        }
+    }
+    
+    fn write_wasm_buffer(&self, env: &ThreaderEnv, input: &[u8]) {
+        let wasm_memory = env.memory_ref().unwrap();
+        let io_buffer = env
+            .get_io_buffer
+            .get_ref()
+            .unwrap()
+            .call()
+            .unwrap();
+        let memory_writer: &[AtomicCell<u8>] = io_buffer
+            .deref(
+                &wasm_memory,
+                0,
+                IO_BUFFER_SIZE_BYTES as u32,
+            )
+            .unwrap();
+
+        for (i, b) in input.iter().enumerate() {
+            memory_writer[i].store(*b);
+        }
+    }
+}
+
+impl PagedBuffer for IoBuffer {
+    fn initialize(&mut self, buffer: Vec<u8>) {
+        self.buffer = buffer;
+    }
+
+    fn first(&mut self, env: &ThreaderEnv) -> i32 {
+        let end: usize = match self.buffer.len() < IO_BUFFER_SIZE_BYTES {
+            true => self.buffer.len(),
+            false => IO_BUFFER_SIZE_BYTES,
+        };
+        self.write_wasm_buffer(
+            env,
+            &self.buffer[0..end],
+        );
+        self.page_idx = 0usize;
+        0
+    }
+
+    fn next(&mut self, env: &ThreaderEnv) -> i32 {
+        if self.buffer.len() > IO_BUFFER_SIZE_BYTES {
+            self.page_idx += 1;
+            self.write_wasm_buffer(
+                env,
+                &self.buffer[IO_BUFFER_SIZE_BYTES * self.page_idx
+                    ..std::cmp::min(IO_BUFFER_SIZE_BYTES * (self.page_idx + 1), self.buffer.len())],
+            );
+        }
+        0
+    }
+
+    fn len(&self) -> usize {
+        self.buffer.len()
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -2,8 +2,6 @@ extern crate lazy_static;
 
 use wasmer::{Array, WasmPtr};
 
-use assemblylift_core_io_common::constants::IO_BUFFER_SIZE_BYTES;
-
 use crate::threader::ThreaderEnv;
 
 pub type WasmBufferPtr = WasmPtr<u8, Array>;
@@ -15,12 +13,9 @@ pub mod threader;
 #[inline(always)]
 pub fn invoke_io(
     env: &ThreaderEnv,
-//    ptr: WasmBufferPtr,
     method_path: &str,
     method_input: Vec<u8>,
 ) -> i32 {
-//    let memory = env.memory_ref().unwrap();
-//    let mem = ptr.deref(memory, 0, IO_BUFFER_SIZE_BYTES as u32).unwrap();
     let ioid = env.threader.clone().lock().unwrap().next_ioid().unwrap();
 
     env.threader

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -15,19 +15,19 @@ pub mod threader;
 #[inline(always)]
 pub fn invoke_io(
     env: &ThreaderEnv,
-    ptr: WasmBufferPtr,
+//    ptr: WasmBufferPtr,
     method_path: &str,
     method_input: Vec<u8>,
 ) -> i32 {
-    let memory = env.memory_ref().unwrap();
-    let mem = ptr.deref(memory, 0, IO_BUFFER_SIZE_BYTES as u32).unwrap();
+//    let memory = env.memory_ref().unwrap();
+//    let mem = ptr.deref(memory, 0, IO_BUFFER_SIZE_BYTES as u32).unwrap();
     let ioid = env.threader.clone().lock().unwrap().next_ioid().unwrap();
 
     env.threader
         .clone()
         .lock()
         .unwrap()
-        .invoke(method_path, method_input, mem.as_ptr(), ioid);
+        .invoke(method_path, method_input, ioid);
 
     ioid as i32
 }

--- a/core/src/threader.rs
+++ b/core/src/threader.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::future::Future;
+use std::iter::Extend;
 use std::sync::{Arc, Mutex};
 use std::mem::ManuallyDrop;
 
@@ -9,15 +10,11 @@ use tokio::sync::mpsc;
 use wasmer::{Array, LazyInit, Memory, NativeFunc, WasmerEnv, WasmPtr};
 
 use assemblylift_core_io_common::constants::IO_BUFFER_SIZE_BYTES;
-use assemblylift_core_io_common::IoMemoryDocument;
 use assemblylift_core_iomod::registry::{RegistryChannelMessage, RegistryTx};
 
-use crate::buffers::{PagedBuffer, IoBuffer};
+use crate::buffers::{LinearBuffer, IoBuffer};
 
-const BLOCK_SIZE_BYTES: usize = 64;
-const NUM_BLOCKS: usize = IO_BUFFER_SIZE_BYTES / BLOCK_SIZE_BYTES;
-
-static IO_MEMORY: Lazy<Mutex<IoMemory>> = Lazy::new(|| Mutex::new(IoMemory::new()));
+static IO_MEMORY: Lazy<Mutex<IoMemory>> = Lazy::new(|| Mutex::new(IoMemory::new(64, 8192)));
 
 #[derive(WasmerEnv, Clone)]
 pub struct ThreaderEnv {
@@ -66,6 +63,7 @@ impl Threader {
             Ok(mut memory) => {
                 match memory.poll(ioid) {
                     true => {
+                        // TODO below maybe not true now
                         // At this point, the document "contents" have already been written to the WASM buffer
                         //    and are read on the guest side immediately after poll() exits.
                         // We can free the host-side memory structure here.
@@ -83,10 +81,10 @@ impl Threader {
         &mut self,
         method_path: &str,
         method_input: Vec<u8>,
-        memory: *const AtomicCell<u8>,
+//        memory: *const AtomicCell<u8>,
         ioid: u32,
     ) {
-        let slc = unsafe { std::slice::from_raw_parts(memory, IO_BUFFER_SIZE_BYTES) };
+//        let slc = unsafe { std::slice::from_raw_parts(memory, IO_BUFFER_SIZE_BYTES) };
         
         let coords = method_path.split(".").collect::<Vec<&str>>();
         if coords.len() != 4 {
@@ -119,7 +117,7 @@ impl Threader {
                     IO_MEMORY
                         .lock()
                         .unwrap()
-                        .write_vec_at(slc, response.payload, ioid);
+                        .handle_response(response.payload, ioid);
                 }
             });
         });
@@ -145,50 +143,88 @@ enum BlockStatus {
 
 #[derive(Copy, Clone)]
 struct Block {
-    status: BlockStatus,
     event_ptr: Option<u32>,
+    offset: Option<usize>,
+    status: BlockStatus,
 }
 
-struct BlockList {
-    list: Box<[Block; NUM_BLOCKS]>,
-}
-
-impl Default for BlockList {
-    fn default() -> Self {
-        let list: Box<[Block; NUM_BLOCKS]> = Box::new(
-            [Block {
-                status: BlockStatus::Free,
-                event_ptr: None,
-            }; NUM_BLOCKS],
-        );
-
-        Self { list }
+impl Block {
+    fn free(&mut self) {
+        self.status = BlockStatus::Free;
+        self.offset = None;
+        self.event_ptr = None;
     }
+
+    fn set(&mut self, ioid: u32, offset: usize) {
+        self.status = BlockStatus::Used;
+        self.event_ptr = Some(ioid);
+        self.offset = Some(offset);
+    }
+}
+
+#[derive(Clone)]
+struct BlockList(Vec<Block>);
+
+impl BlockList {
+    fn new(num_blocks: usize) -> Self {
+        Self(Vec::with_capacity(num_blocks))
+    }
+
+    fn reserve(&mut self, num_blocks: usize) {
+        self.0.reserve(num_blocks);
+    }
+}
+
+impl Extend<Block> for BlockList {
+    fn extend<T: IntoIterator<Item=Block>>(&mut self, iter: T) {
+        for e in iter {
+            self.0.push(e);
+        }
+    }
+}
+
+impl IntoIterator for BlockList {
+    type Item = Block;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+#[derive(Clone)]
+pub struct IoMemoryDocument {
+    pub start: usize,
+    pub length: usize,
 }
 
 struct IoMemory {
     _next_id: u32,
     blocks: BlockList,
+    block_size: usize,
     buffer: IoBuffer,
     document_map: HashMap<u32, IoMemoryDocument>,
     io_status: HashMap<u32, bool>,
+    num_blocks: usize,
 }
 
 impl IoMemory {
-    fn new() -> Self {
+    fn new(block_size: usize, num_blocks: usize) -> Self {
         IoMemory {
             _next_id: 1, // id 0 is reserved (null)
-            blocks: Default::default(),
-            buffer: IoBuffer::new(),
+            blocks: BlockList::new(num_blocks),
+            block_size,
+            buffer: IoBuffer::new(block_size * num_blocks),
             document_map: Default::default(),
             io_status: Default::default(),
+            num_blocks,
         }
     }
 
     fn reset(&mut self) {
         self._next_id = 1;
-        self.blocks = Default::default();
-        self.buffer = IoBuffer::new();
+        self.blocks = BlockList::new(self.num_blocks);
+        self.buffer = IoBuffer::new(self.block_size * self.num_blocks);
         self.document_map.clear();
         self.io_status.clear();
     }
@@ -209,36 +245,24 @@ impl IoMemory {
         }
     }
 
-    // TODO this moves to IoBuffer, partially (where do we update doc map?)
-    fn write_vec_at(&mut self, writer: &[AtomicCell<u8>], vec: Vec<u8>, ioid: u32) {
-        // Serialize the response
-        let vec_len = vec.len();
-        let start = self.alloc(writer, vec_len, ioid);
-        let end = start + vec_len;
-        for i in start..end {
-            writer[i].store(vec[i - start]);
-        }
-
-        // Update document map
-        self.document_map.insert(
-            ioid,
-            IoMemoryDocument {
-                start,
-                length: vec_len,
-            },
-        );
-
-        // Update io status table
+    fn handle_response(&mut self, response: Vec<u8>, ioid: u32) {
+        let offset = self.alloc(response.len(), ioid);
+        self.buffer.write(response.as_slice(), offset);
         self.io_status.insert(ioid, true);
     }
 
-    fn alloc(&mut self, writer: &[AtomicCell<u8>], byte_length: usize, ioid: u32) -> usize {
-        let needed_blocks = (byte_length as f64 / BLOCK_SIZE_BYTES as f64).ceil() as usize;
+    fn alloc(&mut self, byte_length: usize, ioid: u32) -> usize {
+        let needed_blocks = (byte_length as f64 / self.block_size as f64).ceil() as usize;
+        let needed_bytes = needed_blocks * self.block_size;
         let mut available_blocks = 0usize;
         let mut block_list_offset = 0usize;
 
-        for i in 0..NUM_BLOCKS {
-            match self.blocks.list[i].status {
+        if self.buffer.capacity() < needed_bytes {
+            self.grow();
+        }
+
+        for (i, block) in self.blocks.clone().into_iter().enumerate() {
+            match block.status {
                 BlockStatus::Free => {
                     if available_blocks == 0 {
                         block_list_offset = i;
@@ -255,34 +279,41 @@ impl IoMemory {
             }
         }
 
-        println!("DEBUG: available_blocks={} needed_blocks={}", available_blocks, needed_blocks);
-        if available_blocks < needed_blocks {
-            panic!("unable to allocate memory in Threader")
-        }
-
         let block_range = block_list_offset..(block_list_offset + needed_blocks);
         for i in block_range {
-            let byte_range = (i * BLOCK_SIZE_BYTES)..((i * BLOCK_SIZE_BYTES) + BLOCK_SIZE_BYTES);
-            for b in byte_range {
-                writer[b].store(0);
-            }
-            self.blocks.list[i] = Block {
-                status: BlockStatus::Used,
-                event_ptr: Some(ioid),
-            }
+            self.buffer.erase(i * self.block_size, (i * self.block_size) + self.block_size);
+            self.blocks.0.get_mut(i).unwrap().set(ioid, i * self.block_size);
         }
 
-        block_list_offset * BLOCK_SIZE_BYTES
+        let start = block_list_offset * self.block_size;
+
+        self.document_map.insert(
+            ioid,
+            IoMemoryDocument {
+                start,
+                length: byte_length,
+            },
+        );
+
+        start
+    }
+
+    fn grow(&mut self) {
+        self.buffer.double();
+        self.blocks.reserve(self.num_blocks);
+        self.blocks.extend(vec![Block {
+            event_ptr: None,
+            offset: None,
+            status: BlockStatus::Free,
+        }; self.num_blocks]);
+        self.num_blocks *= 2;
     }
 
     fn free(&mut self, ioid: u32) {
-        for i in 0..NUM_BLOCKS {
-            if let Some(event_ptr) = self.blocks.list[i].event_ptr {
+         for mut block in self.blocks.clone().into_iter() {
+            if let Some(event_ptr) = block.event_ptr {
                 if event_ptr == ioid {
-                    self.blocks.list[i] = Block {
-                        status: BlockStatus::Free,
-                        event_ptr: None,
-                    }
+                    block.free();
                 }
             }
         }


### PR DESCRIPTION
This PR brings the dynamic paged buffer implemented in https://github.com/akkoro/assemblylift/pull/45 to the IO memory buffer, which stores responses and other data from IO modules.

This PR is ABI-breaking; `asml_abi_io_ptr` has been removed as it is superseded by `asml_abi_io_load`.