### PR TITLE
Support remote Terraform state

### DIFF
--- a/cli/src/archive.rs
+++ b/cli/src/archive.rs
@@ -114,9 +114,3 @@ pub fn unzip_terraform(bytes_in: Vec<u8>, out_dir: &str) -> Result<(), ArchiveEr
         Err(why) => Err(ArchiveError::new(why.to_string())),
     }
 }
-
-pub fn unzip_iomod(bytes: Vec<u8>, out_dir: &str) {
-    let reader = std::io::Cursor::new(bytes);
-    let mut archive = zip::ZipArchive::new(reader).unwrap();
-    archive.extract(out_dir).expect("could not extract IOmod package");
-}

--- a/cli/src/commands/user.rs
+++ b/cli/src/commands/user.rs
@@ -12,5 +12,5 @@ pub fn command(matches: Option<&ArgMatches>) {
     }
 }
 
-fn command_login(matches: Option<&ArgMatches>) {
+fn command_login(_matches: Option<&ArgMatches>) {
 }

--- a/cli/src/transpiler/asml.rs
+++ b/cli/src/transpiler/asml.rs
@@ -6,6 +6,7 @@ use crate::projectfs::Project as ProjectFs;
 
 pub struct Context {
     pub project: Project,
+    pub terraform: Option<Terraform>,
     pub services: Vec<Service>,
     pub functions: Vec<Function>,
     pub authorizers: Vec<Authorizer>,
@@ -105,6 +106,13 @@ impl Context {
                 name: manifest.project.name.clone(),
                 path: (*project.dir()).into_os_string().into_string().unwrap(),
             },
+            terraform: match manifest.terraform {
+                Some(tf) => Some(Terraform { 
+                    state_bucket_name: tf.state_bucket_name,
+                    lock_table_name: tf.lock_table_name,
+                }),
+                None => None,
+            },
             services: ctx_services,
             functions: ctx_functions,
             authorizers: ctx_authorizers,
@@ -117,6 +125,11 @@ pub struct Project {
     pub name: String,
     pub path: String,
 //    pub version: String,
+}
+
+pub struct Terraform {
+    pub state_bucket_name: String,
+    pub lock_table_name: String,
 }
 
 pub struct Service {

--- a/cli/src/transpiler/toml.rs
+++ b/cli/src/transpiler/toml.rs
@@ -10,11 +10,18 @@ pub mod asml {
     pub struct Manifest {
         pub project: Project,
         pub services: Rc<StringMap<Rc<ServiceRef>>>, // map service_id -> service
+        pub terraform: Option<Terraform>,
     }
 
     #[derive(Deserialize)]
     pub struct Project {
         pub name: String,
+    }
+
+    #[derive(Deserialize)]
+    pub struct Terraform {
+        pub state_bucket_name: String,
+        pub lock_table_name: String,
     }
 
     /* Represents a reference by name to a service (toml::service::Manifest) */


### PR DESCRIPTION
This PR adds support for an optional `terraform` block in `assemblylift.toml`. At this time the block supports only configuration of an S3 backend, requiring an S3 bucket and DynamoDB table.

Example:
```toml
[terraform]
state_bucket_name = "<bucket name>"
lock_table_name = "<table name>"
```