### PR TITLE
[v0.4] Spawn new instance per Lambda event

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Verify Build
 
 on:
   pull_request:
-    branches: [ mainline, v0.4 ]
+    branches: [ mainline, v0.4.0 ]
 
 jobs:
 


### PR DESCRIPTION
Since switching to WASI, repeated calls to `_start` crash the runtime. Try spawning a new Wasmer instance for every invocation and see what the performance is like!