### PR TITLE
Kubelet runtime provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "assemblylift-core",
+ "assemblylift-core-iomod",
  "async-trait",
  "futures",
  "k8s-openapi 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
  "clap 3.0.14",
  "once_cell",
  "reqwest",
- "tokio 1.16.1",
+ "tokio 1.17.0",
  "toml",
  "wasmer",
  "zip",
@@ -121,7 +121,7 @@ dependencies = [
  "assemblylift-core-io-common 0.3.0",
  "assemblylift-core-iomod",
  "once_cell",
- "tokio 1.16.1",
+ "tokio 1.17.0",
  "wasmer",
  "wasmer-wasi",
  "z85",
@@ -205,7 +205,7 @@ dependencies = [
  "paste 1.0.6",
  "rustc_version 0.4.0",
  "serde",
- "tokio 1.16.1",
+ "tokio 1.17.0",
  "tokio-util",
  "toml",
 ]
@@ -253,7 +253,7 @@ dependencies = [
  "oci-distribution",
  "serde_json",
  "tempfile",
- "tokio 1.16.1",
+ "tokio 1.17.0",
  "tracing",
  "tracing-subscriber",
  "wasmer",
@@ -744,12 +744,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
+dependencies = [
+ "darling_core 0.12.4",
+ "darling_macro 0.12.4",
+]
+
+[[package]]
+name = "darling"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.13.1",
+ "darling_macro 0.13.1",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn",
 ]
 
 [[package]]
@@ -768,11 +792,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
+dependencies = [
+ "darling_core 0.12.4",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
 dependencies = [
- "darling_core",
+ "darling_core 0.13.1",
  "quote",
  "syn",
 ]
@@ -898,7 +933,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6451128aa6655d880755345d085494cf7561a6bee7c8dc821e5d77e6d267ecd4"
 dependencies = [
- "darling",
+ "darling 0.13.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -1170,7 +1205,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.16.1",
+ "tokio 1.17.0",
  "tokio-util",
  "tracing",
 ]
@@ -1314,7 +1349,7 @@ dependencies = [
  "itoa 0.4.8",
  "pin-project-lite 0.2.8",
  "socket2",
- "tokio 1.16.1",
+ "tokio 1.17.0",
  "tower-service",
  "tracing",
  "want",
@@ -1328,7 +1363,7 @@ checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
  "hyper",
  "pin-project-lite 0.2.8",
- "tokio 1.16.1",
+ "tokio 1.17.0",
  "tokio-io-timeout",
 ]
 
@@ -1341,7 +1376,7 @@ dependencies = [
  "bytes 1.1.0",
  "hyper",
  "native-tls",
- "tokio 1.16.1",
+ "tokio 1.17.0",
  "tokio-native-tls",
 ]
 
@@ -1586,7 +1621,7 @@ dependencies = [
  "kube-runtime",
  "serde",
  "serde_json",
- "tokio 1.16.1",
+ "tokio 1.17.0",
  "tokio-stream",
  "tracing",
  "tracing-futures",
@@ -1623,6 +1658,7 @@ dependencies = [
  "jsonpath_lib",
  "k8s-openapi",
  "kube-core",
+ "kube-derive",
  "openssl",
  "pem 0.8.3",
  "pin-project 1.0.10",
@@ -1630,7 +1666,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "thiserror",
- "tokio 1.16.1",
+ "tokio 1.17.0",
  "tokio-native-tls",
  "tokio-util",
  "tower",
@@ -1655,6 +1691,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "kube-derive"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4191660b8e26f6e6cb06f21b5372bdbc2c76b54f7c3d65e7a8c8708f9c36ed5"
+dependencies = [
+ "darling 0.12.4",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
 name = "kube-runtime"
 version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1671,7 +1720,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "snafu",
- "tokio 1.16.1",
+ "tokio 1.17.0",
  "tokio-util",
  "tracing",
 ]
@@ -1719,7 +1768,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio 0.2.25",
- "tokio 1.16.1",
+ "tokio 1.17.0",
  "tokio-compat-02",
  "tokio-stream",
  "tonic",
@@ -1929,6 +1978,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
+dependencies = [
+ "libc",
+ "log",
+ "miow 0.3.7",
+ "ntapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "mio-uds"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2102,7 +2164,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "tokio 1.16.1",
+ "tokio 1.17.0",
  "tracing",
  "unicase 1.4.2",
  "url 1.7.2",
@@ -2704,7 +2766,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.16.1",
+ "tokio 1.17.0",
  "tokio-native-tls",
  "tokio-util",
  "url 2.2.2",
@@ -3417,18 +3479,19 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.16.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
 dependencies = [
  "bytes 1.1.0",
  "libc",
  "memchr",
- "mio 0.7.14",
+ "mio 0.8.0",
  "num_cpus",
  "once_cell",
  "pin-project-lite 0.2.8",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros 1.7.0",
  "winapi 0.3.9",
 ]
@@ -3443,7 +3506,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite 0.2.8",
  "tokio 0.2.25",
- "tokio 1.16.1",
+ "tokio 1.17.0",
  "tokio-stream",
 ]
 
@@ -3454,7 +3517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
 dependencies = [
  "pin-project-lite 0.2.8",
- "tokio 1.16.1",
+ "tokio 1.17.0",
 ]
 
 [[package]]
@@ -3486,7 +3549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 1.16.1",
+ "tokio 1.17.0",
 ]
 
 [[package]]
@@ -3496,7 +3559,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
  "rustls",
- "tokio 1.16.1",
+ "tokio 1.17.0",
  "webpki",
 ]
 
@@ -3508,7 +3571,7 @@ checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.8",
- "tokio 1.16.1",
+ "tokio 1.17.0",
  "tokio-util",
 ]
 
@@ -3521,7 +3584,7 @@ dependencies = [
  "futures-util",
  "log",
  "pin-project 1.0.10",
- "tokio 1.16.1",
+ "tokio 1.17.0",
  "tungstenite",
 ]
 
@@ -3538,7 +3601,7 @@ dependencies = [
  "log",
  "pin-project-lite 0.2.8",
  "slab",
- "tokio 1.16.1",
+ "tokio 1.17.0",
 ]
 
 [[package]]
@@ -3571,7 +3634,7 @@ dependencies = [
  "pin-project 1.0.10",
  "prost",
  "prost-derive",
- "tokio 1.16.1",
+ "tokio 1.17.0",
  "tokio-rustls",
  "tokio-stream",
  "tokio-util",
@@ -3607,7 +3670,7 @@ dependencies = [
  "pin-project-lite 0.2.8",
  "rand",
  "slab",
- "tokio 1.16.1",
+ "tokio 1.17.0",
  "tokio-stream",
  "tokio-util",
  "tower-layer",
@@ -3955,7 +4018,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.16.1",
+ "tokio 1.17.0",
  "tokio-rustls",
  "tokio-stream",
  "tokio-tungstenite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,7 @@ dependencies = [
 name = "assemblylift-core"
 version = "0.4.0-alpha.0"
 dependencies = [
+ "anyhow",
  "assemblylift-core-io-common 0.3.0",
  "assemblylift-core-iomod",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,17 +242,20 @@ dependencies = [
  "assemblylift-core",
  "assemblylift-core-iomod",
  "async-trait",
+ "chrono",
+ "clap 3.0.14",
  "futures",
- "k8s-openapi 0.13.1",
+ "k8s-openapi",
  "krator",
  "kube",
  "kube-runtime",
  "kubelet",
- "oci-distribution 0.8.1",
+ "oci-distribution",
  "serde_json",
  "tempfile",
  "tokio 1.16.1",
  "tracing",
+ "tracing-subscriber",
  "wasmer",
 ]
 
@@ -336,15 +339,6 @@ name = "base-x"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
-
-[[package]]
-name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
 
 [[package]]
 name = "base64"
@@ -451,16 +445,6 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
-name = "bytes"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-dependencies = [
- "byteorder",
- "iovec",
-]
 
 [[package]]
 name = "bytes"
@@ -573,6 +557,7 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
+ "term_size",
  "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
@@ -1182,7 +1167,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.6",
+ "http",
  "indexmap",
  "slab",
  "tokio 1.16.1",
@@ -1223,7 +1208,7 @@ dependencies = [
  "bitflags",
  "bytes 1.1.0",
  "headers-core",
- "http 0.2.6",
+ "http",
  "httpdate",
  "mime",
  "sha-1 0.10.0",
@@ -1235,7 +1220,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http 0.2.6",
+ "http",
 ]
 
 [[package]]
@@ -1279,17 +1264,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0"
-dependencies = [
- "bytes 0.4.12",
- "fnv",
- "itoa 0.4.8",
-]
-
-[[package]]
-name = "http"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
@@ -1306,7 +1280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
 dependencies = [
  "bytes 1.1.0",
- "http 0.2.6",
+ "http",
  "pin-project-lite 0.2.8",
 ]
 
@@ -1333,7 +1307,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.6",
+ "http",
  "http-body",
  "httparse",
  "httpdate",
@@ -1373,33 +1347,15 @@ dependencies = [
 
 [[package]]
 name = "hyperx"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a94cbc2c6f63028e5736ca4e811ae36d3990059c384cbe68298c66728a9776"
-dependencies = [
- "base64 0.10.1",
- "bytes 0.4.12",
- "http 0.1.21",
- "httparse",
- "language-tags 0.2.2",
- "log",
- "mime",
- "percent-encoding 1.0.1",
- "time 0.1.43",
- "unicase 2.6.0",
-]
-
-[[package]]
-name = "hyperx"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5617e92fc2f2501c3e2bc6ce547cad841adba2bae5b921c7e52510beca6d084c"
 dependencies = [
  "base64 0.13.0",
  "bytes 1.1.0",
- "http 0.2.6",
+ "http",
  "httpdate",
- "language-tags 0.3.2",
+ "language-tags",
  "mime",
  "percent-encoding 2.1.0",
  "unicase 2.6.0",
@@ -1490,9 +1446,9 @@ checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
@@ -1557,32 +1513,15 @@ dependencies = [
 
 [[package]]
 name = "k8s-csi"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e7390e757d64e9b894e2ccdcfe11774680c5161d94908b6ff4ded0ccb2eeec"
+checksum = "5494bb53430a090bdcfa2677b0c5f19989a3c0cc43e2660f2e0f7d099218ade7"
 dependencies = [
  "prost",
  "prost-build",
  "prost-types",
  "tonic",
  "tonic-build",
-]
-
-[[package]]
-name = "k8s-openapi"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbff78f6da26dde0d74188966d23fc763431d730d0f766ecf7699209f8fc243c"
-dependencies = [
- "base64 0.13.0",
- "bytes 1.1.0",
- "chrono",
- "http 0.2.6",
- "percent-encoding 2.1.0",
- "serde",
- "serde-value",
- "serde_json",
- "url 2.2.2",
 ]
 
 [[package]]
@@ -1594,7 +1533,7 @@ dependencies = [
  "base64 0.13.0",
  "bytes 1.1.0",
  "chrono",
- "http 0.2.6",
+ "http",
  "percent-encoding 2.1.0",
  "serde",
  "serde-value",
@@ -1634,14 +1573,14 @@ dependencies = [
 
 [[package]]
 name = "krator"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb71112409f9b1fe9f2bb6d6a57e679c8c20d8feb186b2485b47842e2874d1a1"
+checksum = "668edc5ad3e89a2ad4c74c62de5c0c7790c146639f5697ce622c2b8ca086d08c"
 dependencies = [
  "anyhow",
  "async-trait",
  "futures",
- "k8s-openapi 0.12.0",
+ "k8s-openapi",
  "krator-derive",
  "kube",
  "kube-runtime",
@@ -1655,9 +1594,9 @@ dependencies = [
 
 [[package]]
 name = "krator-derive"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40288f982cf9b76b3784d652f509557a22fa454a070fd4e79fd9c13673a11066"
+checksum = "4fa674a23c40b90b24a035eef7db57622b8012a6d22725f7f777c28ce91106d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1666,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.58.1"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d3c79fb97a822a63ce9422f7302484748032c808954898ba248705e99ea110"
+checksum = "a0ae4dcb1a65182551922303a2d292b463513a6727db5ad980afbd32df7f3c16"
 dependencies = [
  "base64 0.13.0",
  "bytes 1.1.0",
@@ -1676,13 +1615,15 @@ dependencies = [
  "dirs-next",
  "either",
  "futures",
- "http 0.2.6",
+ "http",
  "http-body",
  "hyper",
  "hyper-timeout",
+ "hyper-tls",
  "jsonpath_lib",
- "k8s-openapi 0.12.0",
+ "k8s-openapi",
  "kube-core",
+ "openssl",
  "pem 0.8.3",
  "pin-project 1.0.10",
  "serde",
@@ -1690,6 +1631,7 @@ dependencies = [
  "serde_yaml",
  "thiserror",
  "tokio 1.16.1",
+ "tokio-native-tls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -1698,14 +1640,15 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.58.1"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbce0d890efc42abb31e974419e25a643a97ab7c6b3b9498bda686d10b55f8d"
+checksum = "04ccd59635e9b21353da8d4a394bb5d3473b5965ed44496c8f857281b0625ffe"
 dependencies = [
  "form_urlencoded",
- "http 0.2.6",
+ "http",
  "json-patch",
- "k8s-openapi 0.12.0",
+ "k8s-openapi",
+ "once_cell",
  "serde",
  "serde_json",
  "thiserror",
@@ -1713,15 +1656,15 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.58.1"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4f034d330a0849e1603e285389e3f0ed93b9a86017d46e851c9e49e6d0b99e2"
+checksum = "eec378b03890f9f2bfa9448a51aa0f6a4299f6bb2ed0d180330e628c7a395918"
 dependencies = [
  "dashmap",
  "derivative",
  "futures",
  "json-patch",
- "k8s-openapi 0.12.0",
+ "k8s-openapi",
  "kube",
  "pin-project 1.0.10",
  "serde",
@@ -1736,8 +1679,6 @@ dependencies = [
 [[package]]
 name = "kubelet"
 version = "1.0.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59817609b940f7a69642c5451d7a148a5cd173a25ea51e6ec650d8ab233c2ed"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -1749,12 +1690,12 @@ dependencies = [
  "either",
  "futures",
  "hostname",
- "http 0.2.6",
+ "http",
  "hyper",
  "iovec",
  "json-patch",
  "k8s-csi",
- "k8s-openapi 0.12.0",
+ "k8s-openapi",
  "kernel32-sys",
  "krator",
  "kube",
@@ -1764,7 +1705,7 @@ dependencies = [
  "mio 0.6.23",
  "miow 0.2.2",
  "notify",
- "oci-distribution 0.7.0",
+ "oci-distribution",
  "prost",
  "prost-types",
  "rcgen",
@@ -1774,6 +1715,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "structopt",
  "tempfile",
  "thiserror",
  "tokio 0.2.25",
@@ -1791,12 +1733,6 @@ dependencies = [
  "winapi 0.2.8",
  "ws2_32-sys",
 ]
-
-[[package]]
-name = "language-tags"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 
 [[package]]
 name = "language-tags"
@@ -1894,6 +1830,15 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "matches"
@@ -2143,33 +2088,13 @@ dependencies = [
 
 [[package]]
 name = "oci-distribution"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c9f50cb73141efc685844c84c98c361429c3a7db550d8d9888af037d93358a7"
-dependencies = [
- "anyhow",
- "futures-util",
- "hyperx 0.13.2",
- "lazy_static",
- "regex",
- "reqwest",
- "serde",
- "serde_json",
- "sha2",
- "tokio 1.16.1",
- "tracing",
- "www-authenticate 0.3.0",
-]
-
-[[package]]
-name = "oci-distribution"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb3c580ad67504493981fff06d790929ece7ce149f344f4d8e411808e5a50f62"
 dependencies = [
  "anyhow",
  "futures-util",
- "hyperx 1.4.0",
+ "hyperx",
  "jwt",
  "lazy_static",
  "regex",
@@ -2181,7 +2106,7 @@ dependencies = [
  "tracing",
  "unicase 1.4.2",
  "url 1.7.2",
- "www-authenticate 0.4.0",
+ "www-authenticate",
 ]
 
 [[package]]
@@ -2486,9 +2411,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
+checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes 1.1.0",
  "prost-derive",
@@ -2496,9 +2421,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
+checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
 dependencies = [
  "bytes 1.1.0",
  "heck",
@@ -2514,9 +2439,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
+checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2527,9 +2452,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
+checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
  "bytes 1.1.0",
  "prost",
@@ -2695,6 +2620,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2755,7 +2689,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.6",
+ "http",
  "http-body",
  "hyper",
  "hyper-tls",
@@ -3112,6 +3046,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3264,6 +3207,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "structopt"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
+dependencies = [
+ "clap 2.34.0",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3301,6 +3268,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "term_size"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3315,6 +3292,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
+ "term_size",
  "unicode-width",
 ]
 
@@ -3342,6 +3320,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -3565,9 +3552,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.4.3"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac42cd97ac6bd2339af5bcabf105540e21e45636ec6fa6aae5e85d44db31be0"
+checksum = "796c5e1cd49905e65dd8e700d4cb1dffcbfdb4fc9d017de08c1a537afd83627c"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3576,9 +3563,10 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.6",
+ "http",
  "http-body",
  "hyper",
+ "hyper-timeout",
  "percent-encoding 2.1.0",
  "pin-project 1.0.10",
  "prost",
@@ -3588,6 +3576,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tower",
+ "tower-layer",
  "tower-service",
  "tracing",
  "tracing-futures",
@@ -3595,9 +3584,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.4.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c695de27302f4697191dda1c7178131a8cb805463dda02864acb80fe1322fdcf"
+checksum = "12b52d07035516c2b74337d2ac7746075e7dcae7643816c1b12c5ff8a7484c08"
 dependencies = [
  "proc-macro2",
  "prost-build",
@@ -3636,7 +3625,7 @@ dependencies = [
  "bytes 1.1.0",
  "futures-core",
  "futures-util",
- "http 0.2.6",
+ "http",
  "http-body",
  "pin-project 1.0.10",
  "tower-layer",
@@ -3687,6 +3676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
 dependencies = [
  "lazy_static",
+ "valuable",
 ]
 
 [[package]]
@@ -3697,6 +3687,49 @@ checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "pin-project 1.0.10",
  "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
+ "ansi_term",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -3723,7 +3756,7 @@ dependencies = [
  "base64 0.13.0",
  "byteorder",
  "bytes 1.1.0",
- "http 0.2.6",
+ "http",
  "httparse",
  "log",
  "rand",
@@ -3850,6 +3883,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3904,7 +3943,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "headers",
- "http 0.2.6",
+ "http",
  "hyper",
  "log",
  "mime",
@@ -4348,22 +4387,11 @@ dependencies = [
 
 [[package]]
 name = "www-authenticate"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c62efb8259cda4e4c732287397701237b78daa4c43edcf3e613c8503a6c07dd"
-dependencies = [
- "hyperx 0.13.2",
- "unicase 1.4.2",
- "url 1.7.2",
-]
-
-[[package]]
-name = "www-authenticate"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02fd1970505d8d9842104b229ba0c6b6331c0897677d0fc0517ea657e77428d0"
 dependencies = [
- "hyperx 1.4.0",
+ "hyperx",
  "unicase 1.4.2",
  "url 1.7.2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1728,6 +1728,7 @@ dependencies = [
 [[package]]
 name = "kubelet"
 version = "1.0.0-alpha.1"
+source = "git+https://github.com/krustlet/krustlet?rev=63cca61#63cca6161ece24aca6a5d0c2a349d4bce7d5241a"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
  "getrandom",
  "once_cell",
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -43,8 +43,14 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
 
 [[package]]
 name = "asml-iomod-registry-common"
@@ -77,7 +83,7 @@ dependencies = [
  "clap 3.0.14",
  "once_cell",
  "reqwest",
- "tokio",
+ "tokio 1.16.1",
  "toml",
  "wasmer",
  "zip",
@@ -114,7 +120,7 @@ dependencies = [
  "assemblylift-core-io-common 0.3.0",
  "assemblylift-core-iomod",
  "once_cell",
- "tokio",
+ "tokio 1.16.1",
  "wasmer",
  "wasmer-wasi",
  "z85",
@@ -198,7 +204,7 @@ dependencies = [
  "paste 1.0.6",
  "rustc_version 0.4.0",
  "serde",
- "tokio",
+ "tokio 1.16.1",
  "tokio-util",
  "toml",
 ]
@@ -228,6 +234,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "assemblylift-kubelet"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "assemblylift-core",
+ "async-trait",
+ "futures",
+ "k8s-openapi 0.13.1",
+ "krator",
+ "kube",
+ "kube-runtime",
+ "kubelet",
+ "oci-distribution 0.8.1",
+ "serde_json",
+ "tempfile",
+ "tokio 1.16.1",
+ "tracing",
+ "wasmer",
+]
+
+[[package]]
+name = "async-recursion"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171374e7e3b2504e0e5236e3b59260560f9fe94bfe9ac39ba5e4e929c5590625"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,7 +305,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -267,6 +337,15 @@ checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
 
 [[package]]
 name = "base64"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
@@ -292,7 +371,25 @@ dependencies = [
  "block-padding",
  "byte-tools",
  "byteorder",
- "generic-array",
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array 0.14.5",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -302,6 +399,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools",
+]
+
+[[package]]
+name = "buf_redux"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
+dependencies = [
+ "memchr",
+ "safemem",
 ]
 
 [[package]]
@@ -342,6 +449,16 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
+dependencies = [
+ "byteorder",
+ "iovec",
+]
 
 [[package]]
 name = "bytes"
@@ -431,6 +548,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time 0.1.43",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +613,15 @@ name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cranelift-bforest"
@@ -597,6 +737,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4600d695eb3f6ce1cd44e6e291adceb2cc3ab12f20a33777ecd0bf6eba34e06"
+dependencies = [
+ "generic-array 0.14.5",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+dependencies = [
+ "generic-array 0.14.5",
+ "subtle",
+]
+
+[[package]]
 name = "darling"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,12 +791,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "num_cpus",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.5",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb780dce4f9a8f5c087362b3a4595936b2019e7c8b30f2c3e9a7e94e6ae9837"
+dependencies = [
+ "block-buffer 0.10.2",
+ "crypto-common",
 ]
 
 [[package]]
@@ -650,10 +849,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
@@ -713,6 +939,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+
+[[package]]
 name = "flate2"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,8 +996,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
- "percent-encoding",
+ "percent-encoding 2.1.0",
 ]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+dependencies = [
+ "bitflags",
+ "fuchsia-zircon-sys",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
@@ -839,7 +1108,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite",
+ "pin-project-lite 0.2.8",
  "pin-utils",
  "slab",
 ]
@@ -860,6 +1129,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+dependencies = [
+ "typenum",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -901,10 +1180,10 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.6",
  "indexmap",
  "slab",
- "tokio",
+ "tokio 1.16.1",
  "tokio-util",
  "tracing",
 ]
@@ -918,7 +1197,7 @@ dependencies = [
  "log",
  "pest",
  "pest_derive",
- "quick-error",
+ "quick-error 2.0.1",
  "serde",
  "serde_json",
 ]
@@ -933,12 +1212,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cff78e5788be1e0ab65b04d306b2ed5092c815ec97ec70f4ebd5aee158aa55d"
+dependencies = [
+ "base64 0.13.0",
+ "bitflags",
+ "bytes 1.1.0",
+ "headers-core",
+ "http 0.2.6",
+ "httpdate",
+ "mime",
+ "sha-1 0.10.0",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http 0.2.6",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "http"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0"
+dependencies = [
+ "bytes 0.4.12",
+ "fnv",
+ "itoa 0.4.8",
 ]
 
 [[package]]
@@ -959,8 +1304,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
 dependencies = [
  "bytes 1.1.0",
- "http",
- "pin-project-lite",
+ "http 0.2.6",
+ "pin-project-lite 0.2.8",
 ]
 
 [[package]]
@@ -986,17 +1331,29 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.6",
  "http-body",
  "httparse",
  "httpdate",
  "itoa 0.4.8",
- "pin-project-lite",
+ "pin-project-lite 0.2.8",
  "socket2",
- "tokio",
+ "tokio 1.16.1",
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite 0.2.8",
+ "tokio 1.16.1",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -1008,8 +1365,42 @@ dependencies = [
  "bytes 1.1.0",
  "hyper",
  "native-tls",
- "tokio",
+ "tokio 1.16.1",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyperx"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a94cbc2c6f63028e5736ca4e811ae36d3990059c384cbe68298c66728a9776"
+dependencies = [
+ "base64 0.10.1",
+ "bytes 0.4.12",
+ "http 0.1.21",
+ "httparse",
+ "language-tags 0.2.2",
+ "log",
+ "mime",
+ "percent-encoding 1.0.1",
+ "time 0.1.43",
+ "unicase 2.6.0",
+]
+
+[[package]]
+name = "hyperx"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5617e92fc2f2501c3e2bc6ce547cad841adba2bae5b921c7e52510beca6d084c"
+dependencies = [
+ "base64 0.13.0",
+ "bytes 1.1.0",
+ "http 0.2.6",
+ "httpdate",
+ "language-tags 0.3.2",
+ "mime",
+ "percent-encoding 2.1.0",
+ "unicase 2.6.0",
 ]
 
 [[package]]
@@ -1017,6 +1408,17 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "idna"
@@ -1041,6 +1443,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,10 +1472,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1077,10 +1517,302 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-patch"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f995a3c8f2bc3dd52a18a583e90f9ec109c047fa1603a853e46bcda14d2e279d"
+dependencies = [
+ "serde",
+ "serde_json",
+ "treediff",
+]
+
+[[package]]
+name = "jsonpath_lib"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaa63191d68230cccb81c5aa23abd53ed64d83337cacbb25a7b8c7979523774f"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "jwt"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98328bb4f360e6b2ceb1f95645602c7014000ef0c3809963df8ad3a3a09f8d99"
+dependencies = [
+ "base64 0.13.0",
+ "crypto-mac",
+ "digest 0.9.0",
+ "hmac",
+ "serde",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
+name = "k8s-csi"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95e7390e757d64e9b894e2ccdcfe11774680c5161d94908b6ff4ded0ccb2eeec"
+dependencies = [
+ "prost",
+ "prost-build",
+ "prost-types",
+ "tonic",
+ "tonic-build",
+]
+
+[[package]]
+name = "k8s-openapi"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbff78f6da26dde0d74188966d23fc763431d730d0f766ecf7699209f8fc243c"
+dependencies = [
+ "base64 0.13.0",
+ "bytes 1.1.0",
+ "chrono",
+ "http 0.2.6",
+ "percent-encoding 2.1.0",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "url 2.2.2",
+]
+
+[[package]]
+name = "k8s-openapi"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f8de9873b904e74b3533f77493731ee26742418077503683db44e1b3c54aa5c"
+dependencies = [
+ "base64 0.13.0",
+ "bytes 1.1.0",
+ "chrono",
+ "http 0.2.6",
+ "percent-encoding 2.1.0",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "url 2.2.2",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "058a107a784f8be94c7d35c1300f4facced2e93d2fbe5b1452b44e905ddca4a9"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
+name = "krator"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb71112409f9b1fe9f2bb6d6a57e679c8c20d8feb186b2485b47842e2874d1a1"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "k8s-openapi 0.12.0",
+ "krator-derive",
+ "kube",
+ "kube-runtime",
+ "serde",
+ "serde_json",
+ "tokio 1.16.1",
+ "tokio-stream",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "krator-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40288f982cf9b76b3784d652f509557a22fa454a070fd4e79fd9c13673a11066"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "kube"
+version = "0.58.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d3c79fb97a822a63ce9422f7302484748032c808954898ba248705e99ea110"
+dependencies = [
+ "base64 0.13.0",
+ "bytes 1.1.0",
+ "chrono",
+ "dirs-next",
+ "either",
+ "futures",
+ "http 0.2.6",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "jsonpath_lib",
+ "k8s-openapi 0.12.0",
+ "kube-core",
+ "pem 0.8.3",
+ "pin-project 1.0.10",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror",
+ "tokio 1.16.1",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tracing",
+]
+
+[[package]]
+name = "kube-core"
+version = "0.58.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbce0d890efc42abb31e974419e25a643a97ab7c6b3b9498bda686d10b55f8d"
+dependencies = [
+ "form_urlencoded",
+ "http 0.2.6",
+ "json-patch",
+ "k8s-openapi 0.12.0",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "kube-runtime"
+version = "0.58.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f034d330a0849e1603e285389e3f0ed93b9a86017d46e851c9e49e6d0b99e2"
+dependencies = [
+ "dashmap",
+ "derivative",
+ "futures",
+ "json-patch",
+ "k8s-openapi 0.12.0",
+ "kube",
+ "pin-project 1.0.10",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "snafu",
+ "tokio 1.16.1",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "kubelet"
+version = "1.0.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59817609b940f7a69642c5451d7a148a5cd173a25ea51e6ec650d8ab233c2ed"
+dependencies = [
+ "anyhow",
+ "async-recursion",
+ "async-stream",
+ "async-trait",
+ "base64 0.13.0",
+ "chrono",
+ "dirs-next",
+ "either",
+ "futures",
+ "hostname",
+ "http 0.2.6",
+ "hyper",
+ "iovec",
+ "json-patch",
+ "k8s-csi",
+ "k8s-openapi 0.12.0",
+ "kernel32-sys",
+ "krator",
+ "kube",
+ "kube-runtime",
+ "lazy_static",
+ "lazycell",
+ "mio 0.6.23",
+ "miow 0.2.2",
+ "notify",
+ "oci-distribution 0.7.0",
+ "prost",
+ "prost-types",
+ "rcgen",
+ "regex",
+ "remove_dir_all 0.7.0",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tempfile",
+ "thiserror",
+ "tokio 0.2.25",
+ "tokio 1.16.1",
+ "tokio-compat-02",
+ "tokio-stream",
+ "tonic",
+ "tonic-build",
+ "tower",
+ "tracing",
+ "tracing-futures",
+ "url 2.2.2",
+ "uuid",
+ "warp",
+ "winapi 0.2.8",
+ "ws2_32-sys",
+]
+
+[[package]]
+name = "language-tags"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
+
+[[package]]
+name = "language-tags"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "leb128"
@@ -1101,8 +1833,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
  "cfg-if 1.0.0",
- "winapi",
+ "winapi 0.3.9",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "log"
@@ -1150,6 +1888,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1186,6 +1930,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
+dependencies = [
+ "mime",
+ "unicase 2.6.0",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1197,15 +1951,57 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
+dependencies = [
+ "cfg-if 0.1.10",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "kernel32-sys",
+ "libc",
+ "log",
+ "miow 0.2.2",
+ "net2",
+ "slab",
+ "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
 dependencies = [
  "libc",
  "log",
- "miow",
+ "miow 0.3.7",
  "ntapi",
- "winapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "mio-uds"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
+dependencies = [
+ "iovec",
+ "libc",
+ "mio 0.6.23",
+]
+
+[[package]]
+name = "miow"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
+dependencies = [
+ "kernel32-sys",
+ "net2",
+ "winapi 0.2.8",
+ "ws2_32-sys",
 ]
 
 [[package]]
@@ -1214,7 +2010,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1222,6 +2018,30 @@ name = "more-asserts"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
+
+[[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "multipart"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00dec633863867f29cb39df64a397cdf4a6354708ddd7759f70c7fb51c5f9182"
+dependencies = [
+ "buf_redux",
+ "httparse",
+ "log",
+ "mime",
+ "mime_guess",
+ "quick-error 1.2.3",
+ "rand",
+ "safemem",
+ "tempfile",
+ "twoway",
+]
 
 [[package]]
 name = "native-tls"
@@ -1242,12 +2062,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "net2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "notify"
+version = "5.0.0-pre.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245d358380e2352c2d020e8ee62baac09b3420f1f6c012a31326cfced4ad487d"
+dependencies = [
+ "bitflags",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "mio 0.7.14",
+ "walkdir",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1272,6 +2140,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "oci-distribution"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f50cb73141efc685844c84c98c361429c3a7db550d8d9888af037d93358a7"
+dependencies = [
+ "anyhow",
+ "futures-util",
+ "hyperx 0.13.2",
+ "lazy_static",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tokio 1.16.1",
+ "tracing",
+ "www-authenticate 0.3.0",
+]
+
+[[package]]
+name = "oci-distribution"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3c580ad67504493981fff06d790929ece7ce149f344f4d8e411808e5a50f62"
+dependencies = [
+ "anyhow",
+ "futures-util",
+ "hyperx 1.4.0",
+ "jwt",
+ "lazy_static",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tokio 1.16.1",
+ "tracing",
+ "unicase 1.4.2",
+ "url 1.7.2",
+ "www-authenticate 0.4.0",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1282,6 +2193,12 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
@@ -1314,6 +2231,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "ordered-float"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1363,6 +2289,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
+dependencies = [
+ "base64 0.13.0",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "pem"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947"
+dependencies = [
+ "base64 0.13.0",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,8 +2360,64 @@ checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
 dependencies = [
  "maplit",
  "pest",
- "sha-1",
+ "sha-1 0.8.2",
 ]
+
+[[package]]
+name = "petgraph"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "pin-project"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9615c18d31137579e9ff063499264ddc1278e7b1982757ebc111028c4d1dc909"
+dependencies = [
+ "pin-project-internal 0.4.29",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+dependencies = [
+ "pin-project-internal 1.0.10",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "044964427019eed9d49d9d5bbce6047ef18f37100ea400912a9fa4a3523ab12a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
@@ -1430,6 +2438,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1439,7 +2453,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -1450,7 +2464,7 @@ checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
  "quote",
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -1466,6 +2480,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "prost"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
+dependencies = [
+ "bytes 1.1.0",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
+dependencies = [
+ "bytes 1.1.0",
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost",
+ "prost-types",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
+dependencies = [
+ "bytes 1.1.0",
+ "prost",
 ]
 
 [[package]]
@@ -1490,6 +2555,12 @@ dependencies = [
 
 [[package]]
 name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
@@ -1501,6 +2572,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -1529,12 +2640,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5911d1403f4143c9d56a702069d593e8d0f3fab880a85e103604d0893ea31ba7"
+dependencies = [
+ "chrono",
+ "pem 1.0.2",
+ "ring",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -1574,7 +2707,7 @@ dependencies = [
  "bitflags",
  "libc",
  "mach",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1583,7 +2716,20 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "remove_dir_all"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882f368737489ea543bc5c340e6f3d34a28c39980bd9a979e47322b26f60ac40"
+dependencies = [
+ "libc",
+ "log",
+ "num_cpus",
+ "rayon",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1607,7 +2753,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.6",
  "http-body",
  "hyper",
  "hyper-tls",
@@ -1617,18 +2763,34 @@ dependencies = [
  "log",
  "mime",
  "native-tls",
- "percent-encoding",
- "pin-project-lite",
+ "percent-encoding 2.1.0",
+ "pin-project-lite 0.2.8",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio",
+ "tokio 1.16.1",
  "tokio-native-tls",
- "url",
+ "tokio-util",
+ "url 2.2.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1687,6 +2849,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64 0.13.0",
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1697,6 +2872,12 @@ name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "same-file"
@@ -1714,14 +2895,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
- "winapi",
+ "winapi 0.3.9",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "seahash"
@@ -1783,6 +2980,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1808,6 +3015,7 @@ version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
 dependencies = [
+ "indexmap",
  "itoa 1.0.1",
  "ryu",
  "serde",
@@ -1826,15 +3034,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a521f2940385c165a24ee286aa8599633d162077a54bdcae2a6fd5a7bfa7a0"
+dependencies = [
+ "indexmap",
+ "ryu",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
  "fake-simd",
- "opaque-debug",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.2",
 ]
 
 [[package]]
@@ -1853,6 +3097,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1865,14 +3131,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
+name = "snafu"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab12d3c261b2308b0d80c26fffb58d17eba81a4be97890101f416b478c79ca7"
+dependencies = [
+ "doc-comment",
+ "futures-core",
+ "pin-project 0.4.29",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1508efa03c362e23817f96cde18abed596a25219a8b2c66e8db33c03543d315b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "socket2"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1886,7 +3181,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
 dependencies = [
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -1967,6 +3262,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
 name = "syn"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1993,8 +3294,8 @@ dependencies = [
  "fastrand",
  "libc",
  "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "remove_dir_all 0.5.3",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2048,7 +3349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2062,8 +3363,8 @@ dependencies = [
  "standback",
  "stdweb",
  "time-macros",
- "version_check",
- "winapi",
+ "version_check 0.9.4",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2106,6 +3407,27 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
+dependencies = [
+ "bytes 0.5.6",
+ "iovec",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "mio 0.6.23",
+ "mio-uds",
+ "num_cpus",
+ "pin-project-lite 0.1.12",
+ "signal-hook-registry",
+ "slab",
+ "tokio-macros 0.2.6",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "tokio"
 version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
@@ -2113,11 +3435,48 @@ dependencies = [
  "bytes 1.1.0",
  "libc",
  "memchr",
- "mio",
+ "mio 0.7.14",
  "num_cpus",
- "pin-project-lite",
- "tokio-macros",
- "winapi",
+ "once_cell",
+ "pin-project-lite 0.2.8",
+ "signal-hook-registry",
+ "tokio-macros 1.7.0",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "tokio-compat-02"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7d4237822b7be8fff0a7a27927462fad435dcb6650f95cea9e946bf6bdc7e07"
+dependencies = [
+ "bytes 0.5.6",
+ "once_cell",
+ "pin-project-lite 0.2.8",
+ "tokio 0.2.25",
+ "tokio 1.16.1",
+ "tokio-stream",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite 0.2.8",
+ "tokio 1.16.1",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2138,7 +3497,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio",
+ "tokio 1.16.1",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls",
+ "tokio 1.16.1",
+ "webpki",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
+dependencies = [
+ "futures-core",
+ "pin-project-lite 0.2.8",
+ "tokio 1.16.1",
+ "tokio-util",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511de3f85caf1c98983545490c3d09685fa8eb634e57eec22bb4db271f46cbd8"
+dependencies = [
+ "futures-util",
+ "log",
+ "pin-project 1.0.10",
+ "tokio 1.16.1",
+ "tungstenite",
 ]
 
 [[package]]
@@ -2152,8 +3547,9 @@ dependencies = [
  "futures-io",
  "futures-sink",
  "log",
- "pin-project-lite",
- "tokio",
+ "pin-project-lite 0.2.8",
+ "slab",
+ "tokio 1.16.1",
 ]
 
 [[package]]
@@ -2164,6 +3560,93 @@ checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "tonic"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac42cd97ac6bd2339af5bcabf105540e21e45636ec6fa6aae5e85d44db31be0"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64 0.13.0",
+ "bytes 1.1.0",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.6",
+ "http-body",
+ "hyper",
+ "percent-encoding 2.1.0",
+ "pin-project 1.0.10",
+ "prost",
+ "prost-derive",
+ "tokio 1.16.1",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c695de27302f4697191dda1c7178131a8cb805463dda02864acb80fe1322fdcf"
+dependencies = [
+ "proc-macro2",
+ "prost-build",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5651b5f6860a99bd1adb59dbfe1db8beb433e73709d9032b413a77e2fb7c066a"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project 1.0.10",
+ "pin-project-lite 0.2.8",
+ "rand",
+ "slab",
+ "tokio 1.16.1",
+ "tokio-stream",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81eca72647e58054bbfa41e6f297c23436f1c60aff6e5eb38455a0f9ca420bb5"
+dependencies = [
+ "base64 0.13.0",
+ "bytes 1.1.0",
+ "futures-core",
+ "futures-util",
+ "http 0.2.6",
+ "http-body",
+ "pin-project 1.0.10",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
 
 [[package]]
 name = "tower-service"
@@ -2179,7 +3662,7 @@ checksum = "2d8d93354fe2a8e50d5953f5ae2e47a3fc2ef03292e7ea46e3cc38f549525fb9"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.2.8",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -2205,10 +3688,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project 1.0.10",
+ "tracing",
+]
+
+[[package]]
+name = "treediff"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "761e8d5ad7ce14bb82b7e61ccc0ca961005a275a060b9644a2431aa11553c2ff"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "tungstenite"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b2d8558abd2e276b0a8df5c05a2ec762609344191e5fd23e292c910e9165b5"
+dependencies = [
+ "base64 0.13.0",
+ "byteorder",
+ "bytes 1.1.0",
+ "http 0.2.6",
+ "httparse",
+ "log",
+ "rand",
+ "sha-1 0.9.8",
+ "thiserror",
+ "url 2.2.2",
+ "utf-8",
+]
+
+[[package]]
+name = "twoway"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "typenum"
@@ -2221,6 +3751,24 @@ name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
+name = "unicase"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
+dependencies = [
+ "version_check 0.1.5",
+]
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check 0.9.4",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -2238,6 +3786,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2250,15 +3804,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "url"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
+dependencies = [
+ "idna 0.1.5",
+ "matches",
+ "percent-encoding 1.0.1",
+]
+
+[[package]]
 name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.2.3",
  "matches",
- "percent-encoding",
+ "percent-encoding 2.1.0",
+]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -2275,6 +3861,12 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+
+[[package]]
+name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
@@ -2286,7 +3878,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
  "same-file",
- "winapi",
+ "winapi 0.3.9",
  "winapi-util",
 ]
 
@@ -2298,6 +3890,37 @@ checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
  "log",
  "try-lock",
+]
+
+[[package]]
+name = "warp"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cef4e1e9114a4b7f1ac799f16ce71c14de5778500c5450ec6b7b920c55b587e"
+dependencies = [
+ "bytes 1.1.0",
+ "futures-channel",
+ "futures-util",
+ "headers",
+ "http 0.2.6",
+ "hyper",
+ "log",
+ "mime",
+ "mime_guess",
+ "multipart",
+ "percent-encoding 2.1.0",
+ "pin-project 1.0.10",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio 1.16.1",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-tungstenite",
+ "tokio-util",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2395,7 +4018,7 @@ dependencies = [
  "wasmer-types",
  "wasmer-vm",
  "wat",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2511,7 +4134,7 @@ dependencies = [
  "wasmer-engine",
  "wasmer-types",
  "wasmer-vm",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2569,7 +4192,7 @@ dependencies = [
  "serde",
  "thiserror",
  "wasmer-types",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2588,7 +4211,7 @@ dependencies = [
  "wasmer",
  "wasmer-vfs",
  "wasmer-wasi-types",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2639,6 +4262,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "which"
 version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2651,6 +4284,12 @@ dependencies = [
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
+name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -2658,6 +4297,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -2671,7 +4316,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2686,7 +4331,57 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
+
+[[package]]
+name = "www-authenticate"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c62efb8259cda4e4c732287397701237b78daa4c43edcf3e613c8503a6c07dd"
+dependencies = [
+ "hyperx 0.13.2",
+ "unicase 1.4.2",
+ "url 1.7.2",
+]
+
+[[package]]
+name = "www-authenticate"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02fd1970505d8d9842104b229ba0c6b6331c0897677d0fc0517ea657e77428d0"
+dependencies = [
+ "hyperx 1.4.0",
+ "unicase 1.4.2",
+ "url 1.7.2",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
+name = "yasna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e262a29d0e61ccf2b6190d7050d4b237535fc76ce4c1210d9caa316f71dffa75"
+dependencies = [
+ "chrono",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "providers/aws-lambda/host",
     "providers/aws-lambda/guest",
+    "providers/kubelet",
     "core",
     "core/guest",
     "core/guest/macros",

--- a/cli/src/commands/cast.rs
+++ b/cli/src/commands/cast.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::fs::copy;
 use std::io::Write;
 use std::path::PathBuf;
 use std::process;
@@ -161,25 +162,25 @@ pub fn command(matches: Option<&ArgMatches>) {
             }
 
             let function_name_snaked = function_name.replace("-", "_");
-            let copy_result = fs::copy(
-                format!(
-                    "{}/target/{}/{}/{}.wasm",
-                    project
-                        .clone()
-                        .service_dir(service_name.clone())
-                        .function_dir(function_name.clone())
-                        .into_os_string()
-                        .into_string()
-                        .unwrap(),
-                    target,
-                    mode,
-                    function_name_snaked
-                ),
-                format!("{}/{}.wasm", function_artifact_path.clone(), &function_name),
-            );
 
+            let copy_from = format!(
+                "{}/target/{}/{}/{}.wasm",
+                project
+                    .clone()
+                    .service_dir(service_name.clone())
+                    .function_dir(function_name.clone())
+                    .into_os_string()
+                    .into_string()
+                    .unwrap(),
+                target,
+                mode,
+                function_name,
+            );
+            let copy_to = format!("{}/{}.wasm", function_artifact_path.clone(), &function_name);
+            let copy_result = fs::copy(copy_from.clone(), copy_to.clone());
             if copy_result.is_err() {
-                println!("ERROR: {:?}", copy_result.err());
+                println!("ERROR COPY from={} to={}", copy_from.clone(), copy_to.clone());
+                panic!("{:?}", copy_result.err());
             }
 
             let wasm_path = format!("{}/{}.wasm", function_artifact_path.clone(), &function_name);

--- a/cli/src/commands/cast.rs
+++ b/cli/src/commands/cast.rs
@@ -161,8 +161,7 @@ pub fn command(matches: Option<&ArgMatches>) {
                 Err(_) => {}
             }
 
-            let function_name_snaked = function_name.replace("-", "_");
-
+            // FIXME this should use the binary name in Cargo.toml if present
             let copy_from = format!(
                 "{}/target/{}/{}/{}.wasm",
                 project

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/akkoro/assemblylift"
 readme = "README.md"
 
 [dependencies]
+anyhow = "1.0"
 once_cell = "1.4"
 tokio = "1.4"
 z85 = "3"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -11,11 +11,14 @@ pub mod wasm;
 
 #[inline(always)]
 /// Invoke an IOmod call at coordinates `method_path` with input `method_input`
-pub fn invoke_io(
-    env: &ThreaderEnv,
+pub fn invoke_io<S>(
+    env: &ThreaderEnv<S>,
     method_path: &str,
     method_input: Vec<u8>,
-) -> i32 {
+) -> i32
+where
+    S: Clone + Send + Sized + 'static
+{
     let ioid = env.threader.clone().lock().unwrap().next_ioid()
         .expect("unable to get a new IO ID");
 

--- a/providers/aws-lambda/host/src/abi.rs
+++ b/providers/aws-lambda/host/src/abi.rs
@@ -9,12 +9,12 @@ use assemblylift_core::threader::ThreaderEnv;
 pub struct LambdaAbi;
 
 impl RuntimeAbi for LambdaAbi {
-    fn log(env: &ThreaderEnv, ptr: u32, len: u32) {
+    fn log(env: &ThreaderEnv<S>, ptr: u32, len: u32) {
         let string = runtime_ptr_to_string(env, ptr, len).unwrap();
         println!("LOG: {}", string);
     }
 
-    fn success(env: &ThreaderEnv, ptr: u32, len: u32) {
+    fn success(env: &ThreaderEnv<S>, ptr: u32, len: u32) {
         let lambda_runtime = &crate::LAMBDA_RUNTIME;
         let response = runtime_ptr_to_string(env, ptr, len).unwrap();
         let threader = env.threader.clone();
@@ -24,7 +24,7 @@ impl RuntimeAbi for LambdaAbi {
     }
 }
 
-fn runtime_ptr_to_string(env: &ThreaderEnv, ptr: u32, len: u32) -> Result<String, io::Error> {
+fn runtime_ptr_to_string(env: &ThreaderEnv<S>, ptr: u32, len: u32) -> Result<String, io::Error> {
     let memory = env.memory_ref().unwrap();
     let view: MemoryView<u8> = memory.view();
 

--- a/providers/aws-lambda/host/src/abi.rs
+++ b/providers/aws-lambda/host/src/abi.rs
@@ -8,7 +8,10 @@ use assemblylift_core::threader::ThreaderEnv;
 
 pub struct LambdaAbi;
 
-impl RuntimeAbi for LambdaAbi {
+impl<S> RuntimeAbi<S> for LambdaAbi
+where
+    S: Clone + Send + Sized + 'static,
+{
     fn log(env: &ThreaderEnv<S>, ptr: u32, len: u32) {
         let string = runtime_ptr_to_string(env, ptr, len).unwrap();
         println!("LOG: {}", string);
@@ -24,7 +27,10 @@ impl RuntimeAbi for LambdaAbi {
     }
 }
 
-fn runtime_ptr_to_string(env: &ThreaderEnv<S>, ptr: u32, len: u32) -> Result<String, io::Error> {
+fn runtime_ptr_to_string<S>(env: &ThreaderEnv<S>, ptr: u32, len: u32) -> Result<String, io::Error>
+where
+    S: Clone + Send + Sized + 'static,
+{
     let memory = env.memory_ref().unwrap();
     let view: MemoryView<u8> = memory.view();
 

--- a/providers/aws-lambda/host/src/main.rs
+++ b/providers/aws-lambda/host/src/main.rs
@@ -16,6 +16,7 @@ use assemblylift_core::buffers::LinearBuffer;
 use assemblylift_core::wasm;
 use assemblylift_core_iomod::{package::IomodManifest, registry};
 use runtime::AwsLambdaRuntime;
+
 use crate::abi::LambdaAbi;
 
 mod abi;

--- a/providers/aws-lambda/host/src/main.rs
+++ b/providers/aws-lambda/host/src/main.rs
@@ -104,11 +104,13 @@ async fn main() {
     let handler_coordinates = env::var("_HANDLER").unwrap();
     let coords = handler_coordinates.split(".").collect::<Vec<&str>>();
 
+    let (status_sender, _status_receiver) = mpsc::channel::<()>(1);
+
     let task_set = tokio::task::LocalSet::new();
     task_set
         .run_until(async move {
             let (module, import_object, env)
-                = match wasm::build_module_from_path::<LambdaAbi>(tx, &lambda_path, coords[0])
+                = match wasm::build_module_from_path::<LambdaAbi, ()>(tx, status_sender, &lambda_path, coords[0])
             {
                 Ok(module) => (Arc::new(module.0), module.1, module.2),
                 Err(_) => panic!("PANIC this shouldn't happen"),

--- a/providers/aws-lambda/host/src/main.rs
+++ b/providers/aws-lambda/host/src/main.rs
@@ -107,7 +107,7 @@ async fn main() {
     task_set
         .run_until(async move {
             let (module, import_object, env)
-                = match wasm::build_module::<LambdaAbi>(tx, &lambda_path, coords[0])
+                = match wasm::build_module_from_path::<LambdaAbi>(tx, &lambda_path, coords[0])
             {
                 Ok(module) => (Arc::new(module.0), module.1, module.2),
                 Err(_) => panic!("PANIC this shouldn't happen"),

--- a/providers/kubelet/Cargo.toml
+++ b/providers/kubelet/Cargo.toml
@@ -9,11 +9,14 @@ async-trait = "0.1"
 chrono = "0.4"
 clap = { version = "3.0", features = ["cargo"] }
 futures = "0.3"
+#hyper = "0.14"
+#k8s-openapi = { version = "0.13", default-features = false, features = ["v1_22", "api"] }
 krator = { version = "0.5", default-features = false, features = ["kube-native-tls"] }
-kube = { version = "0.60", default-features = false, features = ["native-tls"] }
+kube = { version = "0.60", default-features = false, features = ["client", "derive", "native-tls"] }
 kube-runtime = { version = "0.60", default-features = false }
 kubelet = { path = "../../../../Forks/krustlet/crates/kubelet", version = "1.0.0-alpha.1", default-features = false, features = ["derive", "cli", "kube-native-tls"] }
 oci-distribution = { version = "0.8", features = ["native-tls"] }
+#reqwest = { version = "0.11", features = ["blocking"] }
 
 serde_json = "1"
 tempfile = "3.3"

--- a/providers/kubelet/Cargo.toml
+++ b/providers/kubelet/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.3"
 krator = { version = "0.5", default-features = false, features = ["kube-native-tls"] }
 kube = { version = "0.60", default-features = false, features = ["client", "derive", "native-tls"] }
 kube-runtime = { version = "0.60", default-features = false }
-kubelet = { path = "../../../../Forks/krustlet/crates/kubelet", version = "1.0.0-alpha.1", default-features = false, features = ["derive", "cli", "kube-native-tls"] }
+kubelet = { git = "https://github.com/krustlet/krustlet", rev = "63cca61", version = "1.0.0-alpha.1", default-features = false, features = ["derive", "cli", "kube-native-tls"] }
 oci-distribution = { version = "0.8", features = ["native-tls"] }
 #reqwest = { version = "0.11", features = ["blocking"] }
 

--- a/providers/kubelet/Cargo.toml
+++ b/providers/kubelet/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "assemblylift-kubelet"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1"
+async-trait = "0.1"
+futures = "0.3"
+
+krator = { version = "0.4", default-features = false }
+kube = { version = "0.58.1", default-features = false }
+kube-runtime = { version = "0.58.1", default-features = false }
+kubelet = { version = "1.0.0-alpha.1", default-features = false, features = ["derive"] }
+
+serde_json = "1"
+tempfile = "3.3"
+tokio = "1.16"
+tracing = "0.1"
+
+wasmer = "2.1.1"
+
+assemblylift_core = { version = "0.4.0-alpha.0", package = "assemblylift-core", path = "../../core" }
+
+[dev-dependencies]
+k8s-openapi = { version = "0.13", default-features = false, features = ["v1_22", "api"] }
+oci-distribution = "0.8"

--- a/providers/kubelet/Cargo.toml
+++ b/providers/kubelet/Cargo.toml
@@ -6,17 +6,20 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
+chrono = "0.4"
+clap = { version = "3.0", features = ["cargo"] }
 futures = "0.3"
-
-krator = { version = "0.4", default-features = false }
-kube = { version = "0.58.1", default-features = false }
-kube-runtime = { version = "0.58.1", default-features = false }
-kubelet = { version = "1.0.0-alpha.1", default-features = false, features = ["derive"] }
+krator = { version = "0.5", default-features = false, features = ["kube-native-tls"] }
+kube = { version = "0.60", default-features = false, features = ["native-tls"] }
+kube-runtime = { version = "0.60", default-features = false }
+kubelet = { path = "../../../../Forks/krustlet/crates/kubelet", version = "1.0.0-alpha.1", default-features = false, features = ["derive", "cli", "kube-native-tls"] }
+oci-distribution = { version = "0.8", features = ["native-tls"] }
 
 serde_json = "1"
 tempfile = "3.3"
 tokio = "1.16"
 tracing = "0.1"
+tracing-subscriber = "0.2"
 
 wasmer = "2.1.1"
 
@@ -24,5 +27,5 @@ assemblylift-core = { version = "0.4.0-alpha.0", path = "../../core" }
 assemblylift-core-iomod = { version = "0.3.1", path = "../../core/iomod" }
 
 [dev-dependencies]
-k8s-openapi = { version = "0.13", default-features = false, features = ["v1_22", "api"] }
-oci-distribution = "0.8"
+k8s-openapi = { version = "0.13", default-features = false, features = ["v1_22"] }
+#oci-distribution = "0.8"

--- a/providers/kubelet/Cargo.toml
+++ b/providers/kubelet/Cargo.toml
@@ -20,7 +20,8 @@ tracing = "0.1"
 
 wasmer = "2.1.1"
 
-assemblylift_core = { version = "0.4.0-alpha.0", package = "assemblylift-core", path = "../../core" }
+assemblylift-core = { version = "0.4.0-alpha.0", path = "../../core" }
+assemblylift-core-iomod = { version = "0.3.1", path = "../../core/iomod" }
 
 [dev-dependencies]
 k8s-openapi = { version = "0.13", default-features = false, features = ["v1_22", "api"] }

--- a/providers/kubelet/src/abi.rs
+++ b/providers/kubelet/src/abi.rs
@@ -3,13 +3,17 @@ use assemblylift_core::threader::ThreaderEnv;
 
 pub struct KubeletAbi;
 
-impl RuntimeAbi for KubeletAbi {
-    fn log(env: &ThreaderEnv, ptr: u32, len: u32) {
+impl<S> RuntimeAbi<S> for KubeletAbi
+where
+    S: Clone + Send + Sized + 'static
+{
+    fn log(env: &ThreaderEnv<S>, ptr: u32, len: u32) {
         todo!()
     }
 
-    fn success(env: &ThreaderEnv, ptr: u32, len: u32) {
-        // TODO interrupt or state transition (or both!)
+    fn success(env: &ThreaderEnv<S>, ptr: u32, len: u32) {
         todo!()
+        // FIXME not sure yet how to handle this with k8s
+        //      can a status sender be attached to the threaderenv?
     }
 }

--- a/providers/kubelet/src/abi.rs
+++ b/providers/kubelet/src/abi.rs
@@ -1,3 +1,11 @@
+use std::cell::Cell;
+use std::error::Error;
+use std::io;
+use std::io::ErrorKind;
+use tracing::info;
+
+use wasmer::MemoryView;
+
 use assemblylift_core::abi::RuntimeAbi;
 use assemblylift_core::threader::ThreaderEnv;
 
@@ -8,12 +16,35 @@ where
     S: Clone + Send + Sized + 'static
 {
     fn log(env: &ThreaderEnv<S>, ptr: u32, len: u32) {
-        todo!()
+        let string = ptr_to_string(env, ptr, len).unwrap();
+        info!("{}", &string)
     }
 
     fn success(env: &ThreaderEnv<S>, ptr: u32, len: u32) {
         todo!()
-        // FIXME not sure yet how to handle this with k8s
-        //      can a status sender be attached to the threaderenv?
     }
+}
+
+fn ptr_to_string<S>(env: &ThreaderEnv<S>, ptr: u32, len: u32) -> Result<String, io::Error>
+where
+    S: Clone + Send + Sized + 'static
+{
+    let memory = env.memory_ref().unwrap();
+    let view: MemoryView<u8> = memory.view();
+
+    let mut str_vec: Vec<u8> = Vec::new();
+    for byte in view[ptr as usize..(ptr + len) as usize]
+        .iter()
+        .map(Cell::get)
+    {
+        str_vec.push(byte);
+    }
+
+    std::str::from_utf8(str_vec.as_slice())
+        .map(String::from)
+        .map_err(to_io_error)
+}
+
+fn to_io_error<E: Error>(err: E) -> io::Error {
+    io::Error::new(ErrorKind::Other, err.to_string())
 }

--- a/providers/kubelet/src/abi.rs
+++ b/providers/kubelet/src/abi.rs
@@ -9,6 +9,7 @@ impl RuntimeAbi for KubeletAbi {
     }
 
     fn success(env: &ThreaderEnv, ptr: u32, len: u32) {
+        // TODO interrupt or state transition (or both!)
         todo!()
     }
 }

--- a/providers/kubelet/src/abi.rs
+++ b/providers/kubelet/src/abi.rs
@@ -1,0 +1,14 @@
+use assemblylift_core::abi::RuntimeAbi;
+use assemblylift_core::threader::ThreaderEnv;
+
+pub struct KubeletAbi;
+
+impl RuntimeAbi for KubeletAbi {
+    fn log(env: &ThreaderEnv, ptr: u32, len: u32) {
+        todo!()
+    }
+
+    fn success(env: &ThreaderEnv, ptr: u32, len: u32) {
+        todo!()
+    }
+}

--- a/providers/kubelet/src/main.rs
+++ b/providers/kubelet/src/main.rs
@@ -1,0 +1,174 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tempfile::NamedTempFile;
+use tokio::sync::RwLock;
+
+use kubelet::container::Container;
+use kubelet::container::state::prelude::SharedState;
+use kubelet::log::Sender;
+use kubelet::node;
+use kubelet::node::Builder;
+use kubelet::plugin_watcher::PluginRegistry;
+use kubelet::pod::{Handle, Pod, PodKey};
+use kubelet::provider::{DevicePluginSupport, PluginSupport, Provider, ProviderError, VolumeSupport};
+use kubelet::resources::DeviceManager;
+use kubelet::state::common::{GenericProvider, GenericProviderState};
+use kubelet::state::common::registered::Registered;
+use kubelet::state::common::terminated::Terminated;
+use kubelet::store::Store;
+use kubelet::volume::VolumeRef;
+use states::pod::PodState;
+
+use crate::runtime::Runtime;
+
+mod runtime;
+mod states;
+
+pub(crate) type PodHandleMap = Arc<RwLock<HashMap<PodKey, Arc<Handle<Runtime, HandleFactory>>>>>;
+
+pub(crate) struct ModuleRunContext {
+    modules: HashMap<String, Vec<u8>>,
+    volumes: HashMap<String, VolumeRef>,
+    env_vars: HashMap<String, HashMap<String, String>>,
+}
+
+/// Holds our tempfile handle.
+pub struct HandleFactory {
+    temp: Arc<NamedTempFile>,
+}
+
+impl kubelet::log::HandleFactory<tokio::fs::File> for HandleFactory {
+    /// Creates `tokio::fs::File` on demand for log reading.
+    fn new_handle(&self) -> tokio::fs::File {
+        tokio::fs::File::from_std(self.temp.reopen().unwrap())
+    }
+}
+
+/// Provider-level state shared between all pods
+#[derive(Clone)]
+pub struct ProviderState {
+    handles: PodHandleMap,
+    store: Arc<dyn Store + Sync + Send>,
+    log_path: PathBuf,
+    client: kube::Client,
+    volume_path: PathBuf,
+    plugin_registry: Arc<PluginRegistry>,
+    device_plugin_manager: Arc<DeviceManager>,
+}
+
+#[async_trait]
+impl GenericProviderState for ProviderState {
+    fn client(&self) -> kube::Client {
+        self.client.clone()
+    }
+    fn store(&self) -> std::sync::Arc<(dyn Store + Send + Sync + 'static)> {
+        self.store.clone()
+    }
+    async fn stop(&self, pod: &Pod) -> anyhow::Result<()> {
+        let key = PodKey::from(pod);
+        let mut handle_writer = self.handles.write().await;
+        if let Some(handle) = handle_writer.get_mut(&key) {
+            handle.stop().await
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl VolumeSupport for ProviderState {
+    fn volume_path(&self) -> Option<&Path> {
+        Some(self.volume_path.as_ref())
+    }
+}
+
+impl PluginSupport for ProviderState {
+    fn plugin_registry(&self) -> Option<Arc<PluginRegistry>> {
+        Some(self.plugin_registry.clone())
+    }
+}
+
+impl DevicePluginSupport for ProviderState {
+    fn device_plugin_manager(&self) -> Option<Arc<DeviceManager>> {
+        Some(self.device_plugin_manager.clone())
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct RuntimeProvider {
+    shared: ProviderState,
+}
+
+#[async_trait]
+impl Provider for RuntimeProvider {
+    type ProviderState = ProviderState;
+    type PodState = PodState;
+    type InitialState = Registered<Self>;
+    type TerminatedState = Terminated<Self>;
+
+    const ARCH: &'static str = "wasm32-wasi";
+
+    fn provider_state(&self) -> SharedState<ProviderState> {
+        Arc::new(RwLock::new(self.shared.clone()))
+    }
+
+    async fn node(&self, builder: &mut Builder) -> anyhow::Result<()> {
+        builder.set_architecture("wasm-wasi");
+        builder.add_taint("NoSchedule", "kubernetes.io/arch", Self::ARCH);
+        builder.add_taint("NoExecute", "kubernetes.io/arch", Self::ARCH);
+        Ok(())
+    }
+
+    async fn initialize_pod_state(&self, pod: &Pod) -> anyhow::Result<Self::PodState> {
+        Ok(PodState::new(pod))
+    }
+
+    // Evict all pods upon shutdown
+    async fn shutdown(&self, node_name: &str) -> anyhow::Result<()> {
+        node::drain(&self.shared.client, node_name).await?;
+        Ok(())
+    }
+
+    async fn logs(
+        &self,
+        namespace: String,
+        pod_name: String,
+        container_name: String,
+        sender: kubelet::log::Sender,
+    ) -> anyhow::Result<()> {
+        let mut handles = self.shared.handles.write().await;
+        let handle = handles
+            .get_mut(&PodKey::new(&namespace, &pod_name))
+            .ok_or_else(|| ProviderError::PodNotFound {
+                pod_name: pod_name.clone(),
+            })?;
+        handle.output(&container_name, sender).await
+    }
+}
+
+impl GenericProvider for RuntimeProvider {
+    type ProviderState = ProviderState;
+    type PodState = PodState;
+    type RunState = crate::states::pod::initializing::Initializing;
+
+    fn validate_pod_runnable(_pod: &Pod) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn validate_container_runnable(
+        container: &kubelet::container::Container,
+    ) -> anyhow::Result<()> {
+        if let Some(image) = container.image()? {
+            if image.whole().starts_with("k8s.gcr.io/kube-proxy") {
+                return Err(anyhow::anyhow!("Cannot run kube-proxy"));
+            }
+        }
+        Ok(())
+    }
+}
+
+fn main() {
+    println!("Hello, world!");
+}

--- a/providers/kubelet/src/main.rs
+++ b/providers/kubelet/src/main.rs
@@ -19,10 +19,12 @@ use kubelet::store::Store;
 use kubelet::volume::VolumeRef;
 use tempfile::NamedTempFile;
 use tokio::sync::RwLock;
+use assemblylift_core_iomod::registry::RegistryTx;
 
 use crate::runtime::Runtime;
 use crate::states::pod::PodState;
 
+mod abi;
 mod runtime;
 mod states;
 
@@ -56,6 +58,7 @@ pub struct ProviderState {
     volume_path: PathBuf,
     plugin_registry: Arc<PluginRegistry>,
     device_plugin_manager: Arc<DeviceManager>,
+    pub(crate) registry_tx: RegistryTx,
 }
 
 #[async_trait]

--- a/providers/kubelet/src/main.rs
+++ b/providers/kubelet/src/main.rs
@@ -3,9 +3,6 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use tempfile::NamedTempFile;
-use tokio::sync::RwLock;
-
 use kubelet::container::Container;
 use kubelet::container::state::prelude::SharedState;
 use kubelet::log::Sender;
@@ -20,9 +17,11 @@ use kubelet::state::common::registered::Registered;
 use kubelet::state::common::terminated::Terminated;
 use kubelet::store::Store;
 use kubelet::volume::VolumeRef;
-use states::pod::PodState;
+use tempfile::NamedTempFile;
+use tokio::sync::RwLock;
 
 use crate::runtime::Runtime;
+use crate::states::pod::PodState;
 
 mod runtime;
 mod states;
@@ -64,9 +63,11 @@ impl GenericProviderState for ProviderState {
     fn client(&self) -> kube::Client {
         self.client.clone()
     }
+
     fn store(&self) -> std::sync::Arc<(dyn Store + Send + Sync + 'static)> {
         self.store.clone()
     }
+
     async fn stop(&self, pod: &Pod) -> anyhow::Result<()> {
         let key = PodKey::from(pod);
         let mut handle_writer = self.handles.write().await;
@@ -171,4 +172,5 @@ impl GenericProvider for RuntimeProvider {
 
 fn main() {
     println!("Hello, world!");
+    // TODO bootstrap kubelet with RuntimeProvider
 }

--- a/providers/kubelet/src/runtime.rs
+++ b/providers/kubelet/src/runtime.rs
@@ -5,20 +5,39 @@ use std::sync::Arc;
 use kubelet::container::Handle as ContainerHandle;
 use kubelet::container::Status;
 use kubelet::handle::StopHandler;
+use tempfile::NamedTempFile;
 use tokio::sync::mpsc::Sender;
+use tokio::task::JoinHandle;
 
 use assemblylift_core::threader::ThreaderEnv;
 use assemblylift_core::wasm;
 use assemblylift_core::wasm::Resolver;
 use assemblylift_core_iomod::registry::RegistryTx;
+
 use crate::abi::KubeletAbi;
 
-use crate::HandleFactory;
+/// Holds our tempfile handle.
+pub struct HandleFactory {
+    temp: Arc<NamedTempFile>,
+}
+
+impl kubelet::log::HandleFactory<tokio::fs::File> for HandleFactory {
+    /// Creates `tokio::fs::File` on demand for log reading.
+    fn new_handle(&self) -> tokio::fs::File {
+        tokio::fs::File::from_std(self.temp.reopen().unwrap())
+    }
+}
+
+pub struct RuntimeHandle {
+    handle: JoinHandle<()>,
+}
 
 pub struct Runtime {
     module: Arc<wasmer::Module>,
     resolver: Resolver,
     threader_env: ThreaderEnv,
+    tokio: tokio::runtime::Runtime,
+    output: Arc<NamedTempFile>,
 }
 
 impl Runtime {
@@ -32,27 +51,50 @@ impl Runtime {
         log_dir: L,
         status_sender: Sender<Status>,
     ) -> anyhow::Result<Self> {
+        let temp_file = tokio::task::spawn_blocking(move || -> anyhow::Result<NamedTempFile> {
+            Ok(NamedTempFile::new_in(log_dir)?)
+        }).await??;
+
         match wasm::build_module_from_bytes::<KubeletAbi>(registry_tx, &module_data, &name) {
             Ok((module, resolver, threader_env)) => {
                 Ok(Runtime {
-                    module: Arc::new(module),
-                    resolver,
+                    module:  Arc::new(module),
+                    resolver: resolver.clone(),
                     threader_env,
+                    tokio: tokio::runtime::Runtime::new().expect("TODO handle this panic"),
+                    output: Arc::new(temp_file),
                 })
             }
             Err(e) => Err(e),
         }
     }
 
-    pub async fn start(&self) -> anyhow::Result<ContainerHandle<Runtime, HandleFactory>> {
-        // TODO this might work better if the instance is created in Runtime::new along with a tokio runtime,
-        //      then here we can spawn call(_start) on the tk runtime and return the JoinHandle to the kube layer
-        let instance = wasm::new_instance(self.module.clone(), self.resolver.clone()).unwrap(); // FIXME catch error
+    pub async fn start(&self) -> anyhow::Result<ContainerHandle<RuntimeHandle, HandleFactory>> {
+        let hnd = self.tokio.handle().clone();
+        let instance = wasm::new_instance(self.module.clone(), self.resolver.clone())
+            .expect("TODO handle this panic");
+
+        let handle = hnd.spawn(async move {
+            let start = instance.exports.get_function("_start").unwrap();
+            match start.call(&[]) {
+                Ok(result) => println!("SUCCESS: handler returned {:?}", result),
+                Err(error) => println!("ERROR: {}", error.to_string()),
+            }
+        });
+
+        let log_handle_factory = HandleFactory {
+            temp: self.output.clone(),
+        };
+
+        Ok(ContainerHandle::new(
+            RuntimeHandle { handle },
+            log_handle_factory,
+        ))
     }
 }
 
 #[async_trait::async_trait]
-impl StopHandler for Runtime {
+impl StopHandler for RuntimeHandle {
     async fn stop(&mut self) -> anyhow::Result<()> {
         todo!()
     }

--- a/providers/kubelet/src/runtime.rs
+++ b/providers/kubelet/src/runtime.rs
@@ -1,0 +1,38 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use kubelet::container::Handle as ContainerHandle;
+use kubelet::container::Status;
+use kubelet::handle::StopHandler;
+use tokio::sync::mpsc::Sender;
+use crate::HandleFactory;
+
+pub struct Runtime;
+
+impl Runtime {
+    pub async fn new<L: AsRef<Path> + Send + Sync + 'static>(
+        name: String,
+        module_data: Vec<u8>,
+        env: HashMap<String, String>,
+        args: Vec<String>,
+        dirs: HashMap<PathBuf, Option<PathBuf>>,
+        log_dir: L,
+        status_sender: Sender<Status>,
+    ) -> anyhow::Result<Self> {
+        todo!()
+    }
+
+    pub async fn start(&self) -> anyhow::Result<ContainerHandle<Runtime, HandleFactory>> {
+        todo!()
+    }
+}
+
+#[async_trait::async_trait]
+impl StopHandler for Runtime {
+    async fn stop(&mut self) -> anyhow::Result<()> {
+        todo!()
+    }
+
+    async fn wait(&mut self) -> anyhow::Result<()> {
+        todo!()
+    }
+}

--- a/providers/kubelet/src/runtime.rs
+++ b/providers/kubelet/src/runtime.rs
@@ -10,6 +10,8 @@ use tokio::sync::mpsc::Sender;
 use assemblylift_core::threader::ThreaderEnv;
 use assemblylift_core::wasm;
 use assemblylift_core::wasm::Resolver;
+use assemblylift_core_iomod::registry::RegistryTx;
+use crate::abi::KubeletAbi;
 
 use crate::HandleFactory;
 
@@ -23,14 +25,14 @@ impl Runtime {
     pub async fn new<L: AsRef<Path> + Send + Sync + 'static>(
         name: String,
         module_data: Vec<u8>,
+        registry_tx: RegistryTx,
         env: HashMap<String, String>,
         args: Vec<String>,
         dirs: HashMap<PathBuf, Option<PathBuf>>,
         log_dir: L,
         status_sender: Sender<Status>,
     ) -> anyhow::Result<Self> {
-        // TODO `tx` comes from IOmod registry, where does that live?
-        match wasm::build_module_from_bytes(tx, &module_data, &name) {
+        match wasm::build_module_from_bytes::<KubeletAbi>(registry_tx, &module_data, &name) {
             Ok((module, resolver, threader_env)) => {
                 Ok(Runtime {
                     module: Arc::new(module),

--- a/providers/kubelet/src/runtime.rs
+++ b/providers/kubelet/src/runtime.rs
@@ -1,12 +1,23 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
 use kubelet::container::Handle as ContainerHandle;
 use kubelet::container::Status;
 use kubelet::handle::StopHandler;
 use tokio::sync::mpsc::Sender;
+
+use assemblylift_core::threader::ThreaderEnv;
+use assemblylift_core::wasm;
+use assemblylift_core::wasm::Resolver;
+
 use crate::HandleFactory;
 
-pub struct Runtime;
+pub struct Runtime {
+    module: Arc<wasmer::Module>,
+    resolver: Resolver,
+    threader_env: ThreaderEnv,
+}
 
 impl Runtime {
     pub async fn new<L: AsRef<Path> + Send + Sync + 'static>(
@@ -18,11 +29,23 @@ impl Runtime {
         log_dir: L,
         status_sender: Sender<Status>,
     ) -> anyhow::Result<Self> {
-        todo!()
+        // TODO `tx` comes from IOmod registry, where does that live?
+        match wasm::build_module_from_bytes(tx, &module_data, &name) {
+            Ok((module, resolver, threader_env)) => {
+                Ok(Runtime {
+                    module: Arc::new(module),
+                    resolver,
+                    threader_env,
+                })
+            }
+            Err(e) => Err(e),
+        }
     }
 
     pub async fn start(&self) -> anyhow::Result<ContainerHandle<Runtime, HandleFactory>> {
-        todo!()
+        // TODO this might work better if the instance is created in Runtime::new along with a tokio runtime,
+        //      then here we can spawn call(_start) on the tk runtime and return the JoinHandle to the kube layer
+        let instance = wasm::new_instance(self.module.clone(), self.resolver.clone()).unwrap(); // FIXME catch error
     }
 }
 

--- a/providers/kubelet/src/states.rs
+++ b/providers/kubelet/src/states.rs
@@ -1,0 +1,26 @@
+pub(crate) mod container;
+pub(crate) mod pod;
+
+/// When called in a state's `next` function, exits the current state
+/// and transitions to the Error state.
+#[macro_export]
+macro_rules! transition_to_error {
+    ($slf:ident, $err:ident) => {{
+        let aerr = anyhow::Error::from($err);
+        tracing::error!(error = %aerr);
+        let error_state =
+            kubelet::state::common::error::Error::<crate::RuntimeProvider>::new(aerr.to_string());
+        return Transition::next($slf, error_state);
+    }};
+}
+
+/// When called in a state's `next` function, exits the state machine
+/// returns a fatal error to the kubelet.
+#[macro_export]
+macro_rules! fail_fatal {
+    ($err:ident) => {{
+        let aerr = anyhow::Error::from($err);
+        tracing::error!(error = %aerr);
+        return Transition::Complete(Err(aerr));
+    }};
+}

--- a/providers/kubelet/src/states/container.rs
+++ b/providers/kubelet/src/states/container.rs
@@ -1,0 +1,37 @@
+use crate::ModuleRunContext;
+use crate::ProviderState;
+use krator::{ObjectState, SharedState};
+use kubelet::container::{Container, ContainerKey, Status};
+use kubelet::pod::Pod;
+
+pub(crate) mod running;
+pub(crate) mod terminated;
+pub(crate) mod waiting;
+
+pub(crate) struct ContainerState {
+    pod: Pod,
+    container_key: ContainerKey,
+    run_context: SharedState<ModuleRunContext>,
+}
+
+impl ContainerState {
+    pub fn new(
+        pod: Pod,
+        container_key: ContainerKey,
+        run_context: SharedState<ModuleRunContext>,
+    ) -> Self {
+        ContainerState {
+            pod,
+            container_key,
+            run_context,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ObjectState for ContainerState {
+    type Manifest = Container;
+    type Status = Status;
+    type SharedState = ProviderState;
+    async fn async_drop(self, _shared_state: &mut Self::SharedState) {}
+}

--- a/providers/kubelet/src/states/container/running.rs
+++ b/providers/kubelet/src/states/container/running.rs
@@ -1,0 +1,54 @@
+use super::terminated::Terminated;
+use super::ContainerState;
+use crate::ProviderState;
+use kubelet::container::state::prelude::*;
+use tokio::sync::mpsc::Receiver;
+use tracing::{debug, instrument, warn};
+
+/// The container is starting.
+#[derive(Debug, TransitionTo)]
+#[transition_to(Terminated)]
+pub struct Running {
+    rx: Receiver<Status>,
+}
+
+impl Running {
+    pub fn new(rx: Receiver<Status>) -> Self {
+        Running { rx }
+    }
+}
+
+#[async_trait::async_trait]
+impl State<ContainerState> for Running {
+    #[instrument(level = "info", skip(self, _shared_state, _state, _container))]
+    async fn next(
+        mut self: Box<Self>,
+        _shared_state: SharedState<ProviderState>,
+        _state: &mut ContainerState,
+        _container: Manifest<Container>,
+    ) -> Transition<ContainerState> {
+        debug!("Awaiting container status updates");
+        while let Some(status) = self.rx.recv().await {
+            debug!(?status, "Got status update from WASI Runtime");
+            if let Status::Terminated {
+                failed, message, ..
+            } = status
+            {
+                return Transition::next(self, Terminated::new(message, failed));
+            }
+        }
+        warn!("WASI Runtime channel hung up");
+        Transition::next(
+            self,
+            Terminated::new("WASI Runtime channel hung up".to_string(), true),
+        )
+    }
+
+    async fn status(
+        &self,
+        _state: &mut ContainerState,
+        _container: &Container,
+    ) -> anyhow::Result<Status> {
+        Ok(Status::running())
+    }
+}

--- a/providers/kubelet/src/states/container/terminated.rs
+++ b/providers/kubelet/src/states/container/terminated.rs
@@ -1,0 +1,53 @@
+use kubelet::container::state::prelude::*;
+use tracing::{error, instrument};
+
+use crate::ProviderState;
+
+use super::ContainerState;
+
+/// The container is starting.
+#[derive(Debug, TransitionTo)]
+#[transition_to()]
+pub struct Terminated {
+    message: String,
+    failed: bool,
+}
+
+impl Terminated {
+    pub fn new(message: String, failed: bool) -> Self {
+        Terminated { message, failed }
+    }
+}
+
+#[async_trait::async_trait]
+impl State<ContainerState> for Terminated {
+    #[instrument(level = "info", skip(self, _shared_state, _state, container), fields(pod_name = _state.pod.name(), container_name))]
+    async fn next(
+        self: Box<Self>,
+        _shared_state: SharedState<ProviderState>,
+        _state: &mut ContainerState,
+        container: Manifest<Container>,
+    ) -> Transition<ContainerState> {
+        let container = container.latest();
+
+        tracing::Span::current().record("container_name", &container.name());
+
+        if self.failed {
+            error!(
+                error = %self.message,
+                "Pod container exited with error"
+            );
+            Transition::Complete(Err(anyhow::anyhow!(self.message.clone())))
+        } else {
+            Transition::Complete(Ok(()))
+        }
+    }
+
+    async fn status(
+        &self,
+        _state: &mut ContainerState,
+        _container: &Container,
+    ) -> anyhow::Result<Status> {
+        Ok(Status::terminated(&self.message, self.failed))
+    }
+}

--- a/providers/kubelet/src/states/container/waiting.rs
+++ b/providers/kubelet/src/states/container/waiting.rs
@@ -136,10 +136,10 @@ impl State<ContainerState> for Waiting {
             container.name()
         );
 
-        // TODO: decide how/what it means to propagate annotations (from run_context) into WASM modules.
         let runtime = match Runtime::new(
             name,
             module_data,
+            shared.read().await.clone().registry_tx,
             env,
             args,
             container_volumes,

--- a/providers/kubelet/src/states/container/waiting.rs
+++ b/providers/kubelet/src/states/container/waiting.rs
@@ -1,0 +1,207 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+use tracing::{debug, info, instrument};
+
+use kubelet::container::state::prelude::*;
+use kubelet::pod::{Handle as PodHandle, PodKey};
+use kubelet::state::common::GenericProviderState;
+use kubelet::volume::VolumeRef;
+
+use crate::runtime::Runtime;
+use crate::ProviderState;
+
+use super::running::Running;
+use super::terminated::Terminated;
+use super::ContainerState;
+
+fn volume_path_map(
+    container: &Container,
+    volumes: &HashMap<String, VolumeRef>,
+) -> anyhow::Result<HashMap<PathBuf, Option<PathBuf>>> {
+    container
+        .volume_mounts()
+        .iter()
+        .map(|vm| -> anyhow::Result<(PathBuf, Option<PathBuf>)> {
+            // Check the volume exists first
+            let vol = volumes.get(&vm.name).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no volume with the name of {} found for container {}",
+                    vm.name,
+                    container.name()
+                )
+            })?;
+            let host_path = vol
+                .get_path()
+                .map(|p| p.to_owned())
+                .ok_or_else(|| anyhow::anyhow!("Volume {} has not been mounted yet", vm.name))?;
+            let mut guest_path = PathBuf::from(&vm.mount_path);
+            if let Some(sub_path) = &vm.sub_path {
+                guest_path.push(sub_path);
+            }
+            // We can safely assume that this should be valid UTF-8 because it would have
+            // been validated by the k8s API
+            Ok((host_path, Some(guest_path)))
+        })
+        .collect::<anyhow::Result<HashMap<PathBuf, Option<PathBuf>>>>()
+}
+
+/// The container is starting.
+#[derive(Default, Debug, TransitionTo)]
+#[transition_to(Running, Terminated)]
+pub struct Waiting;
+
+#[async_trait::async_trait]
+impl State<ContainerState> for Waiting {
+    #[instrument(
+    level = "info",
+    skip(self, shared, state, container),
+    fields(pod_name = state.pod.name(), container_name)
+    )]
+    async fn next(
+        self: Box<Self>,
+        shared: SharedState<ProviderState>,
+        state: &mut ContainerState,
+        container: Manifest<Container>,
+    ) -> Transition<ContainerState> {
+        let container = container.latest();
+
+        tracing::Span::current().record("container_name", &container.name());
+
+        info!("Starting container for pod");
+
+        let (client, log_path) = {
+            let provider_state = shared.read().await;
+            (provider_state.client(), provider_state.log_path.clone())
+        };
+
+        let (module_data, container_volumes, container_envs) = {
+            let mut run_context = state.run_context.write().await;
+            let module_data = match run_context.modules.remove(container.name()) {
+                Some(data) => data,
+                None => {
+                    return Transition::next(
+                        self,
+                        Terminated::new(
+                            format!(
+                                "Pod {} container {} failed load module data from run context.",
+                                state.pod.name(),
+                                container.name(),
+                            ),
+                            true,
+                        ),
+                    );
+                }
+            };
+            let container_volumes = match volume_path_map(&container, &run_context.volumes) {
+                Ok(volumes) => volumes,
+                Err(e) => {
+                    return Transition::next(
+                        self,
+                        Terminated::new(
+                            format!(
+                                "Pod {} container {} failed to map volume paths: {:?}",
+                                state.pod.name(),
+                                container.name(),
+                                e
+                            ),
+                            true,
+                        ),
+                    )
+                }
+            };
+            (
+                module_data,
+                container_volumes,
+                run_context
+                    .env_vars
+                    .remove(container.name())
+                    .unwrap_or_default(),
+            )
+        };
+
+        let mut env = kubelet::provider::env_vars(&container, &state.pod, &client).await;
+        env.extend(container_envs);
+        let args = container.args().clone();
+
+        // TODO: ~magic~ number
+        let (tx, rx) = mpsc::channel(8);
+
+        let name = format!(
+            "{}:{}:{}",
+            state.pod.namespace(),
+            state.pod.name(),
+            container.name()
+        );
+
+        // TODO: decide how/what it means to propagate annotations (from run_context) into WASM modules.
+        let runtime = match Runtime::new(
+            name,
+            module_data,
+            env,
+            args,
+            container_volumes,
+            log_path,
+            tx,
+        )
+            .await
+        {
+            Ok(runtime) => runtime,
+            Err(e) => {
+                return Transition::next(
+                    self,
+                    Terminated::new(
+                        format!(
+                            "Pod {} container {} failed to construct runtime: {:?}",
+                            state.pod.name(),
+                            container.name(),
+                            e
+                        ),
+                        true,
+                    ),
+                )
+            }
+        };
+        debug!("Starting container on thread");
+        let container_handle = match runtime.start().await {
+            Ok(handle) => handle,
+            Err(e) => {
+                return Transition::next(
+                    self,
+                    Terminated::new(
+                        format!(
+                            "Pod {} container {} failed to start: {:?}",
+                            state.pod.name(),
+                            container.name(),
+                            e
+                        ),
+                        true,
+                    ),
+                )
+            }
+        };
+        debug!("WASI Runtime started for container");
+        let pod_key = PodKey::from(&state.pod);
+        {
+            let provider_state = shared.write().await;
+            let mut handles_writer = provider_state.handles.write().await;
+            let pod_handle = handles_writer
+                .entry(pod_key)
+                .or_insert_with(|| Arc::new(PodHandle::new(HashMap::new(), state.pod.clone())));
+            pod_handle
+                .insert_container_handle(state.container_key.clone(), container_handle)
+                .await;
+        }
+        Transition::next(self, Running::new(rx))
+    }
+
+    async fn status(
+        &self,
+        _state: &mut ContainerState,
+        _container: &Container,
+    ) -> anyhow::Result<Status> {
+        Ok(Status::waiting("Module is starting."))
+    }
+}

--- a/providers/kubelet/src/states/container/waiting.rs
+++ b/providers/kubelet/src/states/container/waiting.rs
@@ -136,7 +136,7 @@ impl State<ContainerState> for Waiting {
             container.name()
         );
 
-        let runtime = match Runtime::new(
+        let runtime = match Runtime::<Status>::new(
             name,
             module_data,
             shared.read().await.clone().registry_tx,

--- a/providers/kubelet/src/states/pod.rs
+++ b/providers/kubelet/src/states/pod.rs
@@ -1,0 +1,111 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use krator::{ObjectState, SharedState};
+use kubelet::backoff::BackoffStrategy;
+use kubelet::backoff::ExponentialBackoffStrategy;
+use kubelet::pod::Pod;
+use kubelet::pod::PodKey;
+use kubelet::pod::Status;
+use kubelet::state::common::{BackoffSequence, GenericPodState, ThresholdTrigger};
+use tokio::sync::RwLock;
+use tracing::error;
+
+use crate::ModuleRunContext;
+use crate::ProviderState;
+
+pub(crate) mod completed;
+pub(crate) mod initializing;
+pub(crate) mod running;
+pub(crate) mod starting;
+
+/// State that is shared between pod state handlers.
+pub struct PodState {
+    key: PodKey,
+    run_context: SharedState<ModuleRunContext>,
+    errors: usize,
+    image_pull_backoff_strategy: ExponentialBackoffStrategy,
+    pub(crate) crash_loop_backoff_strategy: ExponentialBackoffStrategy,
+}
+
+#[async_trait]
+impl ObjectState for PodState {
+    type Manifest = Pod;
+    type Status = Status;
+    type SharedState = ProviderState;
+    async fn async_drop(self, provider_state: &mut Self::SharedState) {
+        {
+            {
+                let mut context = self.run_context.write().await;
+                let unmounts = context.volumes.iter_mut().map(|(k, vol)| async move {
+                    if let Err(e) = vol.unmount().await {
+                        // Just log the error, as there isn't much we can do here
+                        error!(error = %e, volume_name = %k, "Unable to unmount volume");
+                    }
+                });
+                futures::future::join_all(unmounts).await;
+            }
+            let mut handles = provider_state.handles.write().await;
+            handles.remove(&self.key);
+        }
+    }
+}
+
+impl PodState {
+    pub fn new(pod: &Pod) -> Self {
+        let run_context = ModuleRunContext {
+            modules: Default::default(),
+            volumes: Default::default(),
+            env_vars: Default::default(),
+        };
+        let key = PodKey::from(pod);
+        PodState {
+            key,
+            run_context: Arc::new(RwLock::new(run_context)),
+            errors: 0,
+            image_pull_backoff_strategy: ExponentialBackoffStrategy::default(),
+            crash_loop_backoff_strategy: ExponentialBackoffStrategy::default(),
+        }
+    }
+}
+
+#[async_trait]
+impl GenericPodState for PodState {
+    async fn set_env_vars(&mut self, env_vars: HashMap<String, HashMap<String, String>>) {
+        let mut run_context = self.run_context.write().await;
+        run_context.env_vars = env_vars;
+    }
+    async fn set_modules(&mut self, modules: HashMap<String, Vec<u8>>) {
+        let mut run_context = self.run_context.write().await;
+        run_context.modules = modules;
+    }
+    // For this provider, set_volumes extends the current volumes rather than re-assigning
+    async fn set_volumes(&mut self, volumes: HashMap<String, kubelet::volume::VolumeRef>) {
+        let mut run_context = self.run_context.write().await;
+        run_context.volumes.extend(volumes);
+    }
+    async fn backoff(&mut self, sequence: BackoffSequence) {
+        let backoff_strategy = match sequence {
+            BackoffSequence::ImagePull => &mut self.image_pull_backoff_strategy,
+            BackoffSequence::CrashLoop => &mut self.crash_loop_backoff_strategy,
+        };
+        backoff_strategy.wait().await;
+    }
+    async fn reset_backoff(&mut self, sequence: BackoffSequence) {
+        let backoff_strategy = match sequence {
+            BackoffSequence::ImagePull => &mut self.image_pull_backoff_strategy,
+            BackoffSequence::CrashLoop => &mut self.crash_loop_backoff_strategy,
+        };
+        backoff_strategy.reset();
+    }
+    async fn record_error(&mut self) -> ThresholdTrigger {
+        self.errors += 1;
+        if self.errors > 3 {
+            self.errors = 0;
+            ThresholdTrigger::Triggered
+        } else {
+            ThresholdTrigger::Untriggered
+        }
+    }
+}

--- a/providers/kubelet/src/states/pod/completed.rs
+++ b/providers/kubelet/src/states/pod/completed.rs
@@ -1,0 +1,22 @@
+use crate::{PodState, ProviderState};
+use kubelet::pod::state::prelude::*;
+
+/// Pod was deleted.
+#[derive(Default, Debug)]
+pub struct Completed;
+
+#[async_trait::async_trait]
+impl State<PodState> for Completed {
+    async fn next(
+        self: Box<Self>,
+        _provider_state: SharedState<ProviderState>,
+        _pod_state: &mut PodState,
+        _pod: Manifest<Pod>,
+    ) -> Transition<PodState> {
+        Transition::Complete(Ok(()))
+    }
+
+    async fn status(&self, _pod_state: &mut PodState, _pod: &Pod) -> anyhow::Result<PodStatus> {
+        Ok(make_status(Phase::Succeeded, "Completed"))
+    }
+}

--- a/providers/kubelet/src/states/pod/initializing.rs
+++ b/providers/kubelet/src/states/pod/initializing.rs
@@ -1,0 +1,92 @@
+use std::sync::Arc;
+
+use tracing::{error, info, instrument};
+
+use kubelet::backoff::BackoffStrategy;
+use kubelet::container::state::run_to_completion;
+use kubelet::container::ContainerKey;
+use kubelet::pod::state::prelude::*;
+use kubelet::state::common::error::Error;
+use kubelet::state::common::GenericProviderState;
+
+use crate::states::container::waiting::Waiting;
+use crate::states::container::ContainerState;
+use crate::{PodState, ProviderState};
+
+use super::starting::Starting;
+
+#[derive(Default, Debug, TransitionTo)]
+#[transition_to(Starting, Error<crate::RuntimeProvider>)]
+pub struct Initializing;
+
+#[async_trait::async_trait]
+impl State<PodState> for Initializing {
+    #[instrument(
+        level = "info",
+        skip(self, provider_state, pod_state, pod),
+        fields(pod_name)
+    )]
+    async fn next(
+        self: Box<Self>,
+        provider_state: SharedState<ProviderState>,
+        pod_state: &mut PodState,
+        pod: Manifest<Pod>,
+    ) -> Transition<PodState> {
+        let pod_rx = pod.clone();
+        let pod = pod.latest();
+
+        tracing::Span::current().record("pod_name", &pod.name());
+
+        let client = {
+            let provider_state = provider_state.read().await;
+            provider_state.client()
+        };
+
+        for init_container in pod.init_containers() {
+            info!(
+                container_name = init_container.name(),
+                "Starting init container for pod"
+            );
+
+            // Each new init container resets the CrashLoopBackoff timer.
+            pod_state.crash_loop_backoff_strategy.reset();
+
+            let initial_state = Waiting;
+
+            let container_key = ContainerKey::Init(init_container.name().to_string());
+            let container_state = ContainerState::new(
+                pod.clone(),
+                container_key.clone(),
+                Arc::clone(&pod_state.run_context),
+            );
+
+            match run_to_completion(
+                &client,
+                initial_state,
+                // TODO: I think everything should be a SharedState to the same pod in the reflector.
+                Arc::clone(&provider_state),
+                container_state,
+                pod_rx.clone(),
+                container_key,
+            )
+            .await
+            {
+                Ok(_) => (),
+                Err(e) => {
+                    error!(error = %e, "Init container failed");
+                    return Transition::Complete(Err(anyhow::anyhow!(format!(
+                        "Init container {} failed",
+                        init_container.name()
+                    ))));
+                }
+            }
+        }
+        info!("Finished init containers for pod");
+        pod_state.crash_loop_backoff_strategy.reset();
+        Transition::next(self, Starting)
+    }
+
+    async fn status(&self, _pod_state: &mut PodState, _pmeod: &Pod) -> anyhow::Result<PodStatus> {
+        Ok(make_status(Phase::Running, "Initializing"))
+    }
+}

--- a/providers/kubelet/src/states/pod/running.rs
+++ b/providers/kubelet/src/states/pod/running.rs
@@ -1,0 +1,67 @@
+use tokio::sync::mpsc::Receiver;
+
+use kubelet::pod::state::prelude::*;
+use kubelet::state::common::error::Error;
+use kubelet::state::common::GenericProviderState;
+
+use super::completed::Completed;
+use crate::fail_fatal;
+use crate::{PodState, ProviderState};
+
+/// The Kubelet is running the Pod.
+#[derive(Debug, TransitionTo)]
+#[transition_to(Completed, Error<crate::RuntimeProvider>)]
+pub struct Running {
+    rx: Receiver<anyhow::Result<()>>,
+}
+
+impl Running {
+    pub fn new(rx: Receiver<anyhow::Result<()>>) -> Self {
+        Running { rx }
+    }
+}
+
+#[async_trait::async_trait]
+impl State<PodState> for Running {
+    async fn next(
+        mut self: Box<Self>,
+        provider_state: SharedState<ProviderState>,
+        _pod_state: &mut PodState,
+        pod: Manifest<Pod>,
+    ) -> Transition<PodState> {
+        let pod = pod.latest();
+
+        let mut completed = 0;
+        let total_containers = pod.containers().len();
+
+        while let Some(result) = self.rx.recv().await {
+            match result {
+                Ok(()) => {
+                    completed += 1;
+                    if completed == total_containers {
+                        return Transition::next(self, Completed);
+                    }
+                }
+                Err(e) => {
+                    // Stop remaining containers;
+                    {
+                        let provider = provider_state.write().await;
+                        provider.stop(&pod).await.ok();
+                    }
+                    fail_fatal!(e);
+                }
+            }
+        }
+        Transition::next(
+            self,
+            Error::new(format!(
+                "Pod {} container result channel hung up.",
+                pod.name()
+            )),
+        )
+    }
+
+    async fn status(&self, _pod_state: &mut PodState, _pod: &Pod) -> anyhow::Result<PodStatus> {
+        Ok(make_status(Phase::Running, "Running"))
+    }
+}

--- a/providers/kubelet/src/states/pod/starting.rs
+++ b/providers/kubelet/src/states/pod/starting.rs
@@ -1,0 +1,78 @@
+use std::sync::Arc;
+
+use tracing::{info, instrument};
+
+use kubelet::container::state::run_to_completion;
+use kubelet::container::ContainerKey;
+use kubelet::pod::state::prelude::*;
+use kubelet::state::common::GenericProviderState;
+
+use crate::states::container::waiting::Waiting;
+use crate::states::container::ContainerState;
+use crate::{PodState, ProviderState};
+
+use super::running::Running;
+
+#[derive(Default, Debug, TransitionTo)]
+#[transition_to(Running)]
+/// The Kubelet is starting the Pod containers
+pub(crate) struct Starting;
+
+#[async_trait::async_trait]
+impl State<PodState> for Starting {
+    #[instrument(
+        level = "info",
+        skip(self, provider_state, pod_state, pod),
+        fields(pod_name)
+    )]
+    async fn next(
+        self: Box<Self>,
+        provider_state: SharedState<ProviderState>,
+        pod_state: &mut PodState,
+        pod: Manifest<Pod>,
+    ) -> Transition<PodState> {
+        let pod_rx = pod.clone();
+        let pod = pod.latest();
+
+        tracing::Span::current().record("pod_name", &pod.name());
+
+        info!("Starting containers for pod");
+        let containers = pod.containers();
+        let (tx, rx) = tokio::sync::mpsc::channel(containers.len());
+        for container in containers {
+            let initial_state = Waiting;
+            let container_key = ContainerKey::App(container.name().to_string());
+            let container_state = ContainerState::new(
+                pod.clone(),
+                container_key.clone(),
+                Arc::clone(&pod_state.run_context),
+            );
+            let task_provider = Arc::clone(&provider_state);
+            let task_tx = tx.clone();
+            let task_pod = pod_rx.clone();
+            tokio::task::spawn(async move {
+                let client = {
+                    let provider_state = task_provider.read().await;
+                    provider_state.client()
+                };
+
+                let result = run_to_completion(
+                    &client,
+                    initial_state,
+                    task_provider,
+                    container_state,
+                    task_pod,
+                    container_key,
+                )
+                .await;
+                task_tx.send(result).await
+            });
+        }
+        info!("All containers started for pod");
+        Transition::next(self, Running::new(rx))
+    }
+
+    async fn status(&self, _pod_state: &mut PodState, _pod: &Pod) -> anyhow::Result<PodStatus> {
+        Ok(make_status(Phase::Pending, "Starting"))
+    }
+}


### PR DESCRIPTION
This Kubelet implementation is essentially a fork of [Krustlet](https://github.com/krustlet/krustlet) adapted for the AssemblyLift runtime. This is a proof-of-concept and isn't really all that useful as-is, as there is no HTTP or IOmod support yet.

A 'status sender' was added to the Threader environment to accommodate the status channel pattern used by kubelet. The sender is stubbed in the Lambda runtime, but I'll likely convert it to the sender pattern as I like that better anyway :)