### PR TITLE
Terraform Gloo VirtualService instead of using `kubectl`

### DIFF
--- a/cli/src/providers/mod.rs
+++ b/cli/src/providers/mod.rs
@@ -12,7 +12,7 @@ pub mod k8s_hyper_alpine;
 
 pub type ProviderMap = StringMap<Mutex<Box<dyn Provider + Send + Sync>>>;
 
-pub static SERVICE_PROVIDERS: Lazy<ProviderMap> = Lazy::new(|| {
+pub static PROVIDERS: Lazy<ProviderMap> = Lazy::new(|| {
     let mut map = ProviderMap::new();
     map.insert(
         String::from("aws-lambda"),

--- a/cli/src/tools/glooctl.rs
+++ b/cli/src/tools/glooctl.rs
@@ -125,9 +125,9 @@ impl Tool for GlooCtl {
 
     fn fetch_url(&self) -> &str {
         #[cfg(target_os = "linux")]
-        return "https://github.com/solo-io/gloo/releases/download/v1.12.0-beta7/glooctl-linux-amd64";
+        return "https://github.com/solo-io/gloo/releases/download/v1.11.13/glooctl-linux-amd64";
         #[cfg(target_os = "macos")]
-        return "https://github.com/solo-io/gloo/releases/download/v1.12.0-beta7/glooctl-darwin-amd64";
+        return "https://github.com/solo-io/gloo/releases/download/v1.11.13/glooctl-darwin-amd64";
     }
 }
 


### PR DESCRIPTION
Gloo is also rolled back to v1.11 from v1.12-beta