### PR TITLE
Improved project management with `make`, `burn`, and new `move` commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
 dependencies = [
- "gimli 0.26.1",
+ "gimli",
 ]
 
 [[package]]
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
+checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "asml-iomod-registry-common"
@@ -92,11 +92,11 @@ dependencies = [
  "assemblylift-core",
  "assemblylift-core-io-common 0.3.0",
  "assemblylift-core-iomod",
- "clap 3.1.15",
+ "clap 3.2.12",
  "crossbeam-channel",
  "once_cell",
  "reqwest",
- "tokio 1.18.1",
+ "tokio 1.20.0",
  "toml",
  "wasmer",
  "zip 0.5.13",
@@ -140,7 +140,7 @@ dependencies = [
  "assemblylift-core-iomod",
  "crossbeam-channel",
  "once_cell",
- "tokio 1.18.1",
+ "tokio 1.20.0",
  "wasmer",
  "wasmer-wasi",
  "z85",
@@ -224,8 +224,8 @@ dependencies = [
  "paste 1.0.7",
  "rustc_version 0.4.0",
  "serde",
- "tokio 1.18.1",
- "tokio-util 0.6.9",
+ "tokio 1.20.0",
+ "tokio-util 0.6.10",
  "toml",
  "tracing",
 ]
@@ -248,13 +248,13 @@ dependencies = [
  "assemblylift-core",
  "assemblylift-core-iomod",
  "base64 0.13.0",
- "clap 3.1.15",
+ "clap 3.2.12",
  "crossbeam-channel",
  "crossbeam-utils",
  "hyper",
  "serde",
  "serde_json",
- "tokio 1.18.1",
+ "tokio 1.20.0",
  "tracing",
  "tracing-subscriber",
  "wasmer",
@@ -285,7 +285,7 @@ dependencies = [
  "assemblylift-core-iomod",
  "async-trait",
  "chrono",
- "clap 3.1.15",
+ "clap 3.2.12",
  "crossbeam-channel",
  "futures",
  "k8s-openapi 0.13.1",
@@ -296,7 +296,7 @@ dependencies = [
  "oci-distribution",
  "serde_json",
  "tempfile",
- "tokio 1.18.1",
+ "tokio 1.20.0",
  "tracing",
  "tracing-subscriber",
  "wasmer",
@@ -309,10 +309,10 @@ dependencies = [
  "anyhow",
  "assemblylift-core",
  "assemblylift-core-iomod",
- "clap 3.1.15",
+ "clap 3.2.12",
  "crossbeam-channel",
  "hyper",
- "tokio 1.18.1",
+ "tokio 1.20.0",
  "wasmer",
 ]
 
@@ -350,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.53"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
+checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -389,24 +389,24 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.65"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
+checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
 dependencies = [
  "addr2line",
  "cc",
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.29.0",
  "rustc-demangle",
 ]
 
 [[package]]
 name = "base-x"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc19a4937b4fbd3fe3379793130e42060d10627a360f2127802b10b87e7baf74"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
 name = "base64"
@@ -483,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.9.1"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
 name = "byte-tools"
@@ -555,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "capnp"
-version = "0.14.6"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d5d7da973146f1720672faa44f1523cc8f923636190ca1a931c7bc8834de68"
+checksum = "82efa3b0ab5e7e32b786334b052560ec0094135f906975d7481651b9ecf31a6a"
 
 [[package]]
 name = "capnp-futures"
@@ -582,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "capnpc"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7ed9b80f792ac01a8b328ccbc509c2bd756fb5dec18af0163e7963dde23c0b5"
+checksum = "bdc9f1dc84666d4ff007b1a16c8f97db80764a624625979be05d869bcff43aaa"
 dependencies = [
  "capnp",
 ]
@@ -651,15 +651,15 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.15"
+version = "3.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a35a599b11c089a7f49105658d089b8f2cf0882993c17daf6de15285c2c35d"
+checksum = "ab8b79fe3946ceb4a0b1c080b4018992b8d27e9ff363644c1c9b6387c854614d"
 dependencies = [
  "atty",
  "bitflags",
  "clap_lex",
  "indexmap",
- "lazy_static",
+ "once_cell",
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.15.0",
@@ -667,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
@@ -718,6 +718,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "corosensei"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9847f90f32a50b0dcbd68bc23ff242798b13080b97b0569f6ed96a45ce4cf2cd"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "libc",
+ "scopeguard",
+ "windows-sys 0.33.0",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,24 +741,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6bea67967505247f54fa2c85cf4f6e0e31c4e5692c9b70e4ae58e339067333"
+checksum = "38faa2a16616c8e78a18d37b4726b98bfd2de192f2fdc8a39ddf568a408a0f75"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48194035d2752bdd5bdae429e3ab88676e95f52a2b1355a5d4e809f9e39b1d74"
+checksum = "26f192472a3ba23860afd07d2b0217dc628f21fcc72617aa1336d98e1671f33b"
 dependencies = [
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
  "cranelift-entity",
- "gimli 0.25.0",
+ "gimli",
  "log",
  "regalloc",
  "smallvec",
@@ -754,31 +767,30 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976efb22fcab4f2cd6bd4e9913764616a54d895c1a23530128d04e03633c555f"
+checksum = "0f32ddb89e9b89d3d9b36a5b7d7ea3261c98235a76ac95ba46826b8ec40b1a24"
 dependencies = [
  "cranelift-codegen-shared",
- "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dabb5fe66e04d4652e434195b45ae65b5c8172d520247b8f66d8df42b2b45dc"
+checksum = "01fd0d9f288cc1b42d9333b7a776b17e278fc888c28e6a0f09b5573d45a150bc"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3329733e4d4b8e91c809efcaa4faee80bf66f20164e3dd16d707346bd3494799"
+checksum = "9e3bfe172b83167604601faf9dc60453e0d0a93415b57a9c4d1a7ae6849185cf"
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279afcc0d3e651b773f94837c3d581177b348c8d69e928104b2e9fccb226f921"
+checksum = "a006e3e32d80ce0e4ba7f1f9ddf66066d052a8c884a110b91d05404d6ce26dce"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -797,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -818,33 +830,33 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "crossbeam-utils",
- "lazy_static",
  "memoffset",
+ "once_cell",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
 dependencies = [
  "cfg-if 1.0.0",
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.5",
  "typenum",
@@ -1035,15 +1047,15 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.5"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e50f3adc76d6a43f5ed73b698a87d0760ca74617f60f7c3b879003536fdd28"
+checksum = "9d07a982d1fb29db01e5a59b1918e03da4df7297eaeee7686ac45542fd4e59c8"
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "encode_unicode"
@@ -1124,14 +1136,14 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0408e2626025178a6a7f7ffc05a25bc47103229f19c113755de7bf63816290c"
+checksum = "e94a7bbaa59354bc20dd75b67f23e2797b4490e9d6928203fb105c79e448c86c"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
- "winapi 0.3.9",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -1142,13 +1154,11 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39522e96686d38f4bc984b9198e3a0613264abaebaff2c5c918bfa6b6da09af"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
- "cfg-if 1.0.0",
  "crc32fast",
- "libc",
  "miniz_oxide",
 ]
 
@@ -1327,31 +1337,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.25.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 dependencies = [
  "fallible-iterator",
  "indexmap",
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "h2"
@@ -1367,8 +1371,8 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.18.1",
- "tokio-util 0.7.1",
+ "tokio 1.20.0",
+ "tokio-util 0.7.3",
  "tracing",
 ]
 
@@ -1397,9 +1401,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
@@ -1479,9 +1483,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8670570af52249509a86f5e3e18a08c60b177071826898fde8997cf5f6bfbb"
+checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
@@ -1490,9 +1494,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes 1.1.0",
  "http",
@@ -1519,9 +1523,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.18"
+version = "0.14.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b26ae0a80afebe130861d90abf98e3814a4f28a4c6ffeb5ab8ebb2be311e0ef2"
+checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
 dependencies = [
  "bytes 1.1.0",
  "futures-channel",
@@ -1535,7 +1539,7 @@ dependencies = [
  "itoa",
  "pin-project-lite 0.2.9",
  "socket2",
- "tokio 1.18.1",
+ "tokio 1.20.0",
  "tower-service",
  "tracing",
  "want",
@@ -1554,7 +1558,7 @@ dependencies = [
  "openssl",
  "openssl-sys",
  "parking_lot",
- "tokio 1.18.1",
+ "tokio 1.20.0",
  "tokio-openssl",
  "tower-layer",
 ]
@@ -1567,7 +1571,7 @@ checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
  "hyper",
  "pin-project-lite 0.2.9",
- "tokio 1.18.1",
+ "tokio 1.20.0",
  "tokio-io-timeout",
 ]
 
@@ -1580,7 +1584,7 @@ dependencies = [
  "bytes 1.1.0",
  "hyper",
  "native-tls",
- "tokio 1.18.1",
+ "tokio 1.20.0",
  "tokio-native-tls",
 ]
 
@@ -1630,12 +1634,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown 0.11.2",
+ "hashbrown 0.12.3",
  "serde",
 ]
 
@@ -1694,9 +1698,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "jobserver"
@@ -1709,9 +1713,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.57"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
+checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1845,7 +1849,7 @@ dependencies = [
  "kube-runtime 0.60.0",
  "serde",
  "serde_json",
- "tokio 1.18.1",
+ "tokio 1.20.0",
  "tokio-stream",
  "tracing",
  "tracing-futures",
@@ -1885,14 +1889,14 @@ dependencies = [
  "kube-derive 0.60.0",
  "openssl",
  "pem 0.8.3",
- "pin-project 1.0.10",
+ "pin-project 1.0.11",
  "serde",
  "serde_json",
  "serde_yaml",
  "thiserror",
- "tokio 1.18.1",
+ "tokio 1.20.0",
  "tokio-native-tls",
- "tokio-util 0.6.9",
+ "tokio-util 0.6.10",
  "tower",
  "tower-http 0.1.3",
  "tracing",
@@ -1932,15 +1936,15 @@ dependencies = [
  "k8s-openapi 0.14.0",
  "kube-core 0.71.0",
  "openssl",
- "pem 1.0.2",
- "pin-project 1.0.10",
+ "pem 1.1.0",
+ "pin-project 1.0.11",
  "secrecy",
  "serde",
  "serde_json",
  "serde_yaml",
  "thiserror",
- "tokio 1.18.1",
- "tokio-util 0.7.1",
+ "tokio 1.20.0",
+ "tokio-util 0.7.3",
  "tower",
  "tower-http 0.2.5",
  "tracing",
@@ -2018,13 +2022,13 @@ dependencies = [
  "json-patch",
  "k8s-openapi 0.13.1",
  "kube 0.60.0",
- "pin-project 1.0.10",
+ "pin-project 1.0.11",
  "serde",
  "serde_json",
  "smallvec",
  "snafu",
- "tokio 1.18.1",
- "tokio-util 0.6.9",
+ "tokio 1.20.0",
+ "tokio-util 0.6.10",
  "tracing",
 ]
 
@@ -2042,13 +2046,13 @@ dependencies = [
  "k8s-openapi 0.14.0",
  "kube-client",
  "parking_lot",
- "pin-project 1.0.10",
+ "pin-project 1.0.11",
  "serde",
  "serde_json",
  "smallvec",
  "thiserror",
- "tokio 1.18.1",
- "tokio-util 0.7.1",
+ "tokio 1.20.0",
+ "tokio-util 0.7.3",
  "tracing",
 ]
 
@@ -2080,7 +2084,7 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "mio 0.6.23",
- "miow 0.2.2",
+ "miow",
  "notify",
  "oci-distribution",
  "prost",
@@ -2096,7 +2100,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio 0.2.25",
- "tokio 1.18.1",
+ "tokio 1.20.0",
  "tokio-compat-02",
  "tokio-stream",
  "tonic",
@@ -2137,9 +2141,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libloading"
@@ -2153,9 +2157,9 @@ dependencies = [
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linked_hash_set"
@@ -2250,9 +2254,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057a3db23999c867821a7a59feb06a578fcb03685e983dff90daf9e7d24ac08f"
+checksum = "3a79b39c93a7a5a27eeaf9a23b5ff43f1b9e0ad6b1cdd441140ae53c35613fc7"
 dependencies = [
  "libc",
 ]
@@ -2284,9 +2288,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
+checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
 dependencies = [
  "adler",
 ]
@@ -2304,7 +2308,7 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow 0.2.2",
+ "miow",
  "net2",
  "slab",
  "winapi 0.2.8",
@@ -2312,16 +2316,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "miow 0.3.7",
- "ntapi",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "winapi 0.3.9",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -2345,15 +2347,6 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2428,17 +2421,8 @@ dependencies = [
  "inotify",
  "kqueue",
  "libc",
- "mio 0.8.2",
+ "mio 0.8.4",
  "walkdir",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
-dependencies = [
  "winapi 0.3.9",
 ]
 
@@ -2473,22 +2457,31 @@ dependencies = [
 
 [[package]]
 name = "num_threads"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aba1801fb138d8e85e11d0fc70baf4fe1cdfffda7c6cd34a854905df588e5ed0"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "object"
-version = "0.28.3"
+version = "0.28.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
+checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
 dependencies = [
  "crc32fast",
  "hashbrown 0.11.2",
  "indexmap",
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+dependencies = [
  "memchr",
 ]
 
@@ -2508,7 +2501,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.9.9",
- "tokio 1.18.1",
+ "tokio 1.20.0",
  "tracing",
  "unicase 1.4.2",
  "url 1.7.2",
@@ -2517,9 +2510,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "opaque-debug"
@@ -2535,9 +2528,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.39"
+version = "0.10.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28f3916d46d9d813a62d7b7d2724d7b14785ac999fb623d990ee4603f9122742"
+checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -2567,9 +2560,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.73"
+version = "0.9.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5fd19fb3e0a8191c1e34935718976a3e70c112ab9a24af6d7cadccd9d90bc0"
+checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
 dependencies = [
  "autocfg",
  "cc",
@@ -2589,15 +2582,15 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.0.0"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2613,7 +2606,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -2689,9 +2682,9 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947"
+checksum = "03c64931a1a212348ec4f3b4362585eca7159d0d09cbdf4a7f74f02173596fd4"
 dependencies = [
  "base64 0.13.0",
 ]
@@ -2763,27 +2756,27 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9615c18d31137579e9ff063499264ddc1278e7b1982757ebc111028c4d1dc909"
+checksum = "3ef0f924a5ee7ea9cbcea77529dba45f8a9ba9f622419fe3386ca581a3ae9d5a"
 dependencies = [
- "pin-project-internal 0.4.29",
+ "pin-project-internal 0.4.30",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
 dependencies = [
- "pin-project-internal 1.0.10",
+ "pin-project-internal 1.0.11",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "044964427019eed9d49d9d5bbce6047ef18f37100ea400912a9fa4a3523ab12a"
+checksum = "851c8d0ce9bebe43790dedfc86614c23494ac9f423dd618d3a61fc693eafe61e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2792,9 +2785,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2863,11 +2856,11 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2955,9 +2948,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
 ]
@@ -2994,9 +2987,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -3006,9 +2999,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -3023,7 +3016,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5911d1403f4143c9d56a702069d593e8d0f3fab880a85e103604d0893ea31ba7"
 dependencies = [
  "chrono",
- "pem 1.0.2",
+ "pem 1.1.0",
  "ring",
  "yasna",
 ]
@@ -3050,9 +3043,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc"
-version = "0.0.31"
+version = "0.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571f7f397d61c4755285cd37853fe8e03271c243424a907415909379659381c5"
+checksum = "62446b1d3ebf980bdc68837700af1d77b37bc430e524bf95319c6eada2a4cc02"
 dependencies = [
  "log",
  "rustc-hash",
@@ -3061,9 +3054,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3081,9 +3074,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "region"
@@ -3130,9 +3123,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
+checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
 dependencies = [
  "base64 0.13.0",
  "bytes 1.1.0",
@@ -3155,9 +3148,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.18.1",
+ "tokio 1.20.0",
  "tokio-native-tls",
- "tokio-util 0.6.9",
+ "tokio-util 0.7.3",
+ "tower-service",
  "url 2.2.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3182,12 +3176,12 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.38"
+version = "0.7.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517a3034eb2b1499714e9d1e49b2367ad567e07639b69776d35e259d9c27cca6"
+checksum = "cec2b3485b07d96ddfd3134767b8a447b45ea4eb91448d0a35180ec0ffd5ed15"
 dependencies = [
  "bytecheck",
- "hashbrown 0.12.1",
+ "hashbrown 0.12.3",
  "ptr_meta",
  "rend",
  "rkyv_derive",
@@ -3196,9 +3190,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.38"
+version = "0.7.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505c209ee04111a006431abf39696e640838364d67a107c559ababaf6fd8c9dd"
+checksum = "6eaedadc88b53e36dd32d940ed21ae4d850d5916f2581526921f553a72ac34c4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3232,7 +3226,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.9",
+ "semver 1.0.12",
 ]
 
 [[package]]
@@ -3250,15 +3244,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+checksum = "24c8ad4f0c00e1eb5bc7614d236a7f1300e3dbd76b68cac8e06fb00b015ad8d8"
 
 [[package]]
 name = "ryu"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
 name = "safemem"
@@ -3277,12 +3271,12 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
  "lazy_static",
- "winapi 0.3.9",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -3381,9 +3375,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd"
+checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
 
 [[package]]
 name = "semver-parser"
@@ -3393,9 +3387,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
 dependencies = [
  "serde_derive",
 ]
@@ -3421,9 +3415,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3443,9 +3437,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
  "indexmap",
  "itoa",
@@ -3467,9 +3461,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.24"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707d15895415db6628332b737c838b88c598522e4dc70647e59b72312924aebc"
+checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
  "indexmap",
  "ryu",
@@ -3589,9 +3583,9 @@ checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "snafu"
@@ -3601,7 +3595,7 @@ checksum = "eab12d3c261b2308b0d80c26fffb58d17eba81a4be97890101f416b478c79ca7"
 dependencies = [
  "doc-comment",
  "futures-core",
- "pin-project 0.4.29",
+ "pin-project 0.4.30",
  "snafu-derive",
 ]
 
@@ -3756,20 +3750,20 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.92"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fa7e55043acb85fca6b3c01485a2eeb6b69c5d21002e273c79e465f43b7ac1"
+checksum = "c02424087780c9b71cc96799eaeddff35af2bc513278cda5c99fc1f5d026d3c1"
 
 [[package]]
 name = "tempfile"
@@ -3887,9 +3881,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
 dependencies = [
  "itoa",
  "libc",
@@ -3964,21 +3958,22 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.18.1"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce653fb475565de9f6fb0614b28bca8df2c430c0cf84bcd9c843f15de5414cc"
+checksum = "57aec3cfa4c296db7255446efb4928a6be304b431a806216105542a67b6ca82e"
 dependencies = [
+ "autocfg",
  "bytes 1.1.0",
  "libc",
  "memchr",
- "mio 0.8.2",
+ "mio 0.8.4",
  "num_cpus",
  "once_cell",
  "parking_lot",
  "pin-project-lite 0.2.9",
  "signal-hook-registry",
  "socket2",
- "tokio-macros 1.7.0",
+ "tokio-macros 1.8.0",
  "winapi 0.3.9",
 ]
 
@@ -3992,7 +3987,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite 0.2.9",
  "tokio 0.2.25",
- "tokio 1.18.1",
+ "tokio 1.20.0",
  "tokio-stream",
 ]
 
@@ -4003,7 +3998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
 dependencies = [
  "pin-project-lite 0.2.9",
- "tokio 1.18.1",
+ "tokio 1.20.0",
 ]
 
 [[package]]
@@ -4019,9 +4014,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4035,7 +4030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 1.18.1",
+ "tokio 1.20.0",
 ]
 
 [[package]]
@@ -4047,7 +4042,7 @@ dependencies = [
  "futures-util",
  "openssl",
  "openssl-sys",
- "tokio 1.18.1",
+ "tokio 1.20.0",
 ]
 
 [[package]]
@@ -4057,20 +4052,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
  "rustls",
- "tokio 1.18.1",
+ "tokio 1.20.0",
  "webpki",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
+checksum = "df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.9",
- "tokio 1.18.1",
- "tokio-util 0.6.9",
+ "tokio 1.20.0",
+ "tokio-util 0.7.3",
 ]
 
 [[package]]
@@ -4081,16 +4076,16 @@ checksum = "511de3f85caf1c98983545490c3d09685fa8eb634e57eec22bb4db271f46cbd8"
 dependencies = [
  "futures-util",
  "log",
- "pin-project 1.0.10",
- "tokio 1.18.1",
+ "pin-project 1.0.11",
+ "tokio 1.20.0",
  "tungstenite",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
 dependencies = [
  "bytes 1.1.0",
  "futures-core",
@@ -4099,21 +4094,21 @@ dependencies = [
  "log",
  "pin-project-lite 0.2.9",
  "slab",
- "tokio 1.18.1",
+ "tokio 1.20.0",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
+checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
 dependencies = [
  "bytes 1.1.0",
  "futures-core",
  "futures-sink",
  "pin-project-lite 0.2.9",
  "slab",
- "tokio 1.18.1",
+ "tokio 1.20.0",
  "tracing",
 ]
 
@@ -4144,13 +4139,13 @@ dependencies = [
  "hyper",
  "hyper-timeout",
  "percent-encoding 2.1.0",
- "pin-project 1.0.10",
+ "pin-project 1.0.11",
  "prost",
  "prost-derive",
- "tokio 1.18.1",
+ "tokio 1.20.0",
  "tokio-rustls",
  "tokio-stream",
- "tokio-util 0.6.9",
+ "tokio-util 0.6.10",
  "tower",
  "tower-layer",
  "tower-service",
@@ -4172,19 +4167,19 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a89fd63ad6adf737582df5db40d286574513c69a11dac5214dc3b5603d6713e"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
  "indexmap",
- "pin-project 1.0.10",
+ "pin-project 1.0.11",
  "pin-project-lite 0.2.9",
  "rand",
  "slab",
- "tokio 1.18.1",
- "tokio-util 0.7.1",
+ "tokio 1.20.0",
+ "tokio-util 0.7.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4202,7 +4197,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
- "pin-project 1.0.10",
+ "pin-project 1.0.11",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4236,15 +4231,15 @@ checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
 
 [[package]]
 name = "tower-service"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
+checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -4255,9 +4250,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
+checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4266,11 +4261,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.26"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
+checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
- "lazy_static",
+ "once_cell",
  "valuable",
 ]
 
@@ -4280,7 +4275,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project 1.0.10",
+ "pin-project 1.0.11",
  "tracing",
 ]
 
@@ -4378,9 +4373,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+checksum = "89570599c4fe5585de2b388aab47e99f7fa4e9238a1399f707a02e356058141c"
 
 [[package]]
 name = "unicase"
@@ -4407,10 +4402,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
-name = "unicode-normalization"
-version = "0.1.19"
+name = "unicode-ident"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
 dependencies = [
  "tinyvec",
 ]
@@ -4426,12 +4427,6 @@ name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "untrusted"
@@ -4545,16 +4540,16 @@ dependencies = [
  "mime_guess",
  "multipart",
  "percent-encoding 2.1.0",
- "pin-project 1.0.10",
+ "pin-project 1.0.11",
  "scoped-tls",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.18.1",
+ "tokio 1.20.0",
  "tokio-rustls",
  "tokio-stream",
  "tokio-tungstenite",
- "tokio-util 0.6.9",
+ "tokio-util 0.6.10",
  "tower-service",
  "tracing",
 ]
@@ -4573,9 +4568,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -4583,9 +4578,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -4598,9 +4593,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
+checksum = "de9a9cec1733468a8c657e57fa2413d2ae2c0129b95e87c5b72b8ace4d13f31f"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -4610,9 +4605,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4620,9 +4615,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4633,15 +4628,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
+
+[[package]]
+name = "wasm-encoder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f76068e87fe9b837a6bc2ccded66784173eadb828c4168643e9fddf6f9ed2e61"
+dependencies = [
+ "leb128",
+]
 
 [[package]]
 name = "wasmer"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f727a39e7161f7438ddb8eafe571b67c576a8c2fb459f666d9053b5bba4afdea"
+checksum = "ea8d8361c9d006ea3d7797de7bd6b1492ffd0f91a22430cfda6c1658ad57bedf"
 dependencies = [
  "cfg-if 1.0.0",
  "indexmap",
@@ -4651,6 +4655,7 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "wasm-bindgen",
+ "wasmer-artifact",
  "wasmer-compiler",
  "wasmer-compiler-cranelift",
  "wasmer-derive",
@@ -4664,10 +4669,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmer-compiler"
-version = "2.2.1"
+name = "wasmer-artifact"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e9951599222eb12bd13d4d91bcded0a880e4c22c2dfdabdf5dc7e5e803b7bf3"
+checksum = "7aaf9428c29c1d8ad2ac0e45889ba8a568a835e33fd058964e5e500f2f7ce325"
+dependencies = [
+ "enumset",
+ "loupe",
+ "thiserror",
+ "wasmer-compiler",
+ "wasmer-types",
+]
+
+[[package]]
+name = "wasmer-compiler"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67a6cd866aed456656db2cfea96c18baabbd33f676578482b85c51e1ee19d2c"
 dependencies = [
  "enumset",
  "loupe",
@@ -4678,20 +4696,19 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "wasmer-types",
- "wasmer-vm",
  "wasmparser",
 ]
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c83273bce44e668f3a2b9ccb7f1193db918b1d6806f64acc5ff71f6ece5f20"
+checksum = "48be2f9f6495f08649e4f8b946a2cbbe119faf5a654aa1457f9504a99d23dae0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
- "gimli 0.25.0",
+ "gimli",
  "loupe",
  "more-asserts",
  "rayon",
@@ -4700,14 +4717,13 @@ dependencies = [
  "tracing",
  "wasmer-compiler",
  "wasmer-types",
- "wasmer-vm",
 ]
 
 [[package]]
 name = "wasmer-derive"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458dbd9718a837e6dbc52003aef84487d79eedef5fa28c7d28b6784be98ac08e"
+checksum = "00e50405cc2a2f74ff574584710a5f2c1d5c93744acce2ca0866084739284b51"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -4717,9 +4733,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed603a6d037ebbb14014d7f739ae996a78455a4b86c41cfa4e81c590a1253b9"
+checksum = "3f98f010978c244db431b392aeab0661df7ea0822343334f8f2a920763548e45"
 dependencies = [
  "backtrace",
  "enumset",
@@ -4732,6 +4748,7 @@ dependencies = [
  "serde_bytes",
  "target-lexicon",
  "thiserror",
+ "wasmer-artifact",
  "wasmer-compiler",
  "wasmer-types",
  "wasmer-vm",
@@ -4739,9 +4756,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd7fdc60e252a795c849b3f78a81a134783051407e7e279c10b7019139ef8dc"
+checksum = "ad0358af9c154724587731175553805648d9acb8f6657880d165e378672b7e53"
 dependencies = [
  "cfg-if 1.0.0",
  "enum-iterator",
@@ -4749,11 +4766,12 @@ dependencies = [
  "leb128",
  "libloading",
  "loupe",
- "object",
+ "object 0.28.4",
  "rkyv",
  "serde",
  "tempfile",
  "tracing",
+ "wasmer-artifact",
  "wasmer-compiler",
  "wasmer-engine",
  "wasmer-object",
@@ -4764,12 +4782,11 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcff0cd2c01a8de6009fd863b14ea883132a468a24f2d2ee59dc34453d3a31b5"
+checksum = "440dc3d93c9ca47865a4f4edd037ea81bf983b5796b59b3d712d844b32dbef15"
 dependencies = [
  "cfg-if 1.0.0",
- "enum-iterator",
  "enumset",
  "leb128",
  "loupe",
@@ -4777,18 +4794,35 @@ dependencies = [
  "rkyv",
  "wasmer-compiler",
  "wasmer-engine",
+ "wasmer-engine-universal-artifact",
  "wasmer-types",
  "wasmer-vm",
  "winapi 0.3.9",
 ]
 
 [[package]]
-name = "wasmer-object"
-version = "2.2.1"
+name = "wasmer-engine-universal-artifact"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ce18ac2877050e59580d27ee1a88f3192d7a31e77fbba0852abc7888d6e0b5"
+checksum = "68f1db3f54152657eb6e86c44b66525ff7801dad8328fe677da48dd06af9ad41"
 dependencies = [
- "object",
+ "enum-iterator",
+ "enumset",
+ "loupe",
+ "rkyv",
+ "thiserror",
+ "wasmer-artifact",
+ "wasmer-compiler",
+ "wasmer-types",
+]
+
+[[package]]
+name = "wasmer-object"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d831335ff3a44ecf451303f6f891175c642488036b92ceceb24ac8623a8fa8b"
+dependencies = [
+ "object 0.28.4",
  "thiserror",
  "wasmer-compiler",
  "wasmer-types",
@@ -4796,12 +4830,15 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "659fa3dd6c76f62630deff4ac8c7657b07f0b1e4d7e0f8243a552b9d9b448e24"
+checksum = "39df01ea05dc0a9bab67e054c7cb01521e53b35a7bb90bd02eca564ed0b2667f"
 dependencies = [
+ "backtrace",
+ "enum-iterator",
  "indexmap",
  "loupe",
+ "more-asserts",
  "rkyv",
  "serde",
  "thiserror",
@@ -4809,9 +4846,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vfs"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02fc47308cf5cf2cc039ec61c098773320b3d3c099434f20580bd143beee63b"
+checksum = "9302eae3edc53cb540c2d681e7f16d8274918c1ce207591f04fed351649e97c0"
 dependencies = [
  "libc",
  "thiserror",
@@ -4820,32 +4857,37 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdc46158517c2769f9938bc222a7d41b3bb330824196279d8aa2d667cd40641"
+checksum = "30d965fa61f4dc4cdb35a54daaf7ecec3563fbb94154a6c35433f879466247dd"
 dependencies = [
  "backtrace",
  "cc",
  "cfg-if 1.0.0",
+ "corosensei",
  "enum-iterator",
  "indexmap",
+ "lazy_static",
  "libc",
  "loupe",
+ "mach",
  "memoffset",
  "more-asserts",
  "region",
  "rkyv",
+ "scopeguard",
  "serde",
  "thiserror",
+ "wasmer-artifact",
  "wasmer-types",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "wasmer-wasi"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3087d48fe015928118ae23f66f05b533e75fbea5dfcd64c75a74b7b5f941cc65"
+checksum = "fadbe31e3c1b6f3e398ad172b169152ae1a743ae6efd5f9ffb34019983319d99"
 dependencies = [
  "cfg-if 1.0.0",
  "generational-arena",
@@ -4862,9 +4904,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-wasi-types"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69adbd8d0d89cd19fb8b1e0252c76e3f72dbc65c944f0db7a9c28c4157fbcd3a"
+checksum = "22dc83aadbdf97388de3211cb6f105374f245a3cf2a5c65a16776e7a087a8468"
 dependencies = [
  "byteorder",
  "time 0.2.27",
@@ -4873,35 +4915,36 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.78.2"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
+checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
 
 [[package]]
 name = "wast"
-version = "40.0.0"
+version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb4f48a8b083dbc50e291e430afb8f524092bb00428957bcc63f49f856c64ac"
+checksum = "5f474d1b1cb7d92e5360b293f28e8bc9b2d115197a5bbf76bdbfba9161cf9cdc"
 dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
+ "wasm-encoder",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.42"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0401b6395ce0db91629a75b29597ccb66ea29950af9fc859f1bb3a736609c76e"
+checksum = "82d002ce2eca0730c6df2c21719e9c4d8d0cafe74fb0cb8ff137c0774b8e4ed1"
 dependencies = [
  "wast",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.57"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
+checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4973,16 +5016,35 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43dbb096663629518eb1dfa72d80243ca5a6aca764cae62a2df70af760a9be75"
+dependencies = [
+ "windows_aarch64_msvc 0.33.0",
+ "windows_i686_gnu 0.33.0",
+ "windows_i686_msvc 0.33.0",
+ "windows_x86_64_gnu 0.33.0",
+ "windows_x86_64_msvc 0.33.0",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd761fd3eb9ab8cc1ed81e56e567f02dd82c4c837e48ac3b2181b9ffc5060807"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4992,9 +5054,21 @@ checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_i686_gnu"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab0cf703a96bab2dc0c02c0fa748491294bf9b7feb27e1f4f96340f208ada0e"
+
+[[package]]
+name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfdbe89cc9ad7ce618ba34abc34bbb6c36d99e96cae2245b7943cd75ee773d0"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5004,9 +5078,21 @@ checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4dd9b0c0e9ece7bb22e84d70d01b71c6d6248b81a3c60d11869451b4cb24784"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff1e4aa646495048ec7f3ffddc411e1d829c026a2ec62b39da15c1055e406eaa"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5070,9 +5156,9 @@ checksum = "2a599daf1b507819c1121f0bf87fa37eb19daac6aff3aefefd4e6e2e0f2020fc"
 
 [[package]]
 name = "zeroize"
-version = "1.5.5"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94693807d016b2f2d2e14420eb3bfcca689311ff775dcf113d74ea624b7cdf07"
+checksum = "20b578acffd8516a6c3f2a1bdefc1ec37e547bb4e0fb8b6b01a4cafc886b4442"
 
 [[package]]
 name = "zip"
@@ -5104,24 +5190,24 @@ dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
  "sha1 0.10.1",
- "time 0.3.9",
+ "time 0.3.11",
  "zstd",
 ]
 
 [[package]]
 name = "zstd"
-version = "0.10.0+zstd.1.5.2"
+version = "0.10.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b1365becbe415f3f0fcd024e2f7b45bacfb5bdd055f0dc113571394114e7bdd"
+checksum = "5f4a6bd64f22b5e3e94b4e238669ff9f10815c27a5180108b849d24174a83847"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "4.1.4+zstd.1.5.2"
+version = "4.1.6+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7cd17c9af1a4d6c24beb1cc54b17e2ef7b593dc92f19e9d9acad8b182bbaee"
+checksum = "94b61c51bb270702d6167b8ce67340d2754b088d0c091b06e593aa772c3ee9bb"
 dependencies = [
  "libc",
  "zstd-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,13 +104,14 @@ dependencies = [
 
 [[package]]
 name = "assemblylift-cli"
-version = "0.4.0-alpha.3"
+version = "0.4.0-alpha.4"
 dependencies = [
  "asml-iomod-registry-common",
  "assemblylift-core-iomod",
  "base64 0.13.0",
  "bytes 1.1.0",
  "clap 2.34.0",
+ "dialoguer",
  "handlebars",
  "itertools",
  "k8s-openapi 0.14.0",
@@ -674,6 +675,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "regex",
+ "terminal_size",
+ "unicode-width",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "const_fn"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -936,6 +952,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c8ae48e400addc32a8710c8d62d55cb84249a7d58ac4cd959daecfbaddc545"
+dependencies = [
+ "console",
+ "tempfile",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,6 +1044,12 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -3769,6 +3802,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "assemblylift-cli"
 version = "0.4.0-alpha.4"
-description = "AssemblyLift command line interface"
+description = "The AssemblyLift Command Line Interface"
 authors = ["Akkoro and the AssemblyLift contributors <assemblylift@akkoro.io>"]
 edition = "2018"
 license-file = "../LICENSE.md"
@@ -16,8 +16,8 @@ path = "src/main.rs"
 [dependencies]
 base64 = "0.13"
 bytes = "1.1"
-z85 = "3"
 clap = "2.33"
+dialoguer = "0.10"
 handlebars = "3.5"
 itertools = "0.10"
 once_cell = "1.7"
@@ -26,6 +26,7 @@ serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 toml = "0.5"
 walkdir = "2.3"
+z85 = "3"
 zip = "0.6"
 
 kube = { version = "0.71.0", features = ["runtime", "derive"] }

--- a/cli/src/commands/burn.rs
+++ b/cli/src/commands/burn.rs
@@ -1,7 +1,103 @@
+use std::rc::Rc;
+
 use clap::ArgMatches;
+use dialoguer::Confirm;
 
+use crate::projectfs::{locate_asml_manifest, Project};
 use crate::terraform;
+use crate::transpiler::toml::asml::ServiceRef;
+use crate::transpiler::toml::{asml, service};
 
-pub fn command(_matches: Option<&ArgMatches>) {
-    terraform::commands::destroy();
+pub fn command(matches: Option<&ArgMatches>) {
+    let matches = match matches {
+        Some(matches) => matches,
+        _ => panic!("could not get matches for make command"),
+    };
+
+    let manifest = match locate_asml_manifest() {
+        Some(manifest) => manifest,
+        None => panic!("could not find assemblylift.toml in tree"),
+    };
+    let mut manifest_dir = manifest.1.clone();
+    manifest_dir.pop();
+
+    let project = Project::new(manifest.0.project.name.clone(), Some(manifest_dir.clone()));
+
+    let mut resource_type: Option<&str> = None;
+    let mut resource_name: Option<&str> = None;
+    for el in matches
+        .values_of("resource")
+        .expect("must specify either 'service', 'function' as an argument to burn")
+    {
+        if resource_type.is_none() {
+            resource_type = Some(el);
+            continue;
+        }
+        if resource_name.is_none() {
+            resource_name = Some(el);
+            continue;
+        }
+    }
+
+    match resource_type {
+        // Some("all") => terraform::commands::destroy(),
+
+        Some("service") => {
+            let service_name = resource_name.unwrap();
+            if Confirm::new()
+                .with_prompt(format!(
+                    "Are you sure you want to destroy service \"{}\"?\nThis is PERMANENT!",
+                    service_name
+                ))
+                .interact()
+                .unwrap()
+            {
+                let mut manifest: asml::Manifest = manifest.0.clone();
+                manifest.remove_service(service_name);
+                manifest
+                    .write(manifest_dir.clone())
+                    .expect("could not write assemblylift.toml");
+
+                let mut service_dir = manifest_dir.clone();
+                service_dir.push("services");
+                service_dir.push(service_name);
+                std::fs::remove_dir_all(service_dir).expect("could not remove service directory");
+            }
+        }
+
+        Some("function") => {
+            let resource_name = resource_name.unwrap().to_string();
+            let function_name: Vec<&str> = resource_name.split(".").collect();
+            if function_name.len() != 2 {
+                panic!("syntax is `burn function <service>.<function>`")
+            }
+
+            if Confirm::new()
+                .with_prompt(format!(
+                    "Are you sure you want to destroy function \"{}\"\nThis is PERMANENT!",
+                    resource_name
+                ))
+                .interact()
+                .unwrap()
+            {
+                let service_dir = &*project.service_dir(function_name[0].into()).dir().clone();
+                let mut manifest_file = service_dir.clone();
+                manifest_file.push("service.toml");
+                let mut service_manifest = service::Manifest::read(&manifest_file).unwrap();
+                service_manifest.remove_function(function_name[1]);
+                service_manifest.write(service_dir.clone()).unwrap();
+                std::fs::remove_dir_all(
+                    &*project
+                        .service_dir(function_name[0].into())
+                        .function_dir(function_name[1].into()),
+                )
+                .expect("could not remove service directory");
+            }
+        }
+
+        Some(_) => {
+            panic!("must specify either 'service', 'function', or 'all' as an argument to burn")
+        }
+        None => panic!("must specify either 'service', 'function' or 'all' as an argument to burn"),
+    }
 }

--- a/cli/src/commands/burn.rs
+++ b/cli/src/commands/burn.rs
@@ -95,9 +95,7 @@ pub fn command(matches: Option<&ArgMatches>) {
             }
         }
 
-        Some(_) => {
-            panic!("must specify either 'service', 'function', or 'all' as an argument to burn")
-        }
+        Some(_) => panic!("must specify either 'service', 'function', or 'all' as an argument to burn"),
         None => panic!("must specify either 'service', 'function' or 'all' as an argument to burn"),
     }
 }

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -20,7 +20,7 @@ pub fn command(matches: Option<&ArgMatches>) {
     let default_service_name = "my-service";
     let default_function_name = "my-function";
     let project_name = matches.value_of("project_name").unwrap();
-    let function_language = matches.value_of("language").unwrap();
+    // let function_language = matches.value_of("language").unwrap();
 
     let project = Project::new(project_name.parse().unwrap(), None);
 
@@ -45,10 +45,10 @@ pub fn command(matches: Option<&ArgMatches>) {
             "service_name".to_string(),
             to_json(default_service_name.to_string()),
         );
-        data.insert(
-            "function_language".to_string(),
-            to_json(function_language.to_string()),
-        );
+        // data.insert(
+        //     "function_language".to_string(),
+        //     to_json(function_language.to_string()),
+        // );
         write_documents(
             &project
                 .service_dir(String::from(default_service_name))
@@ -58,46 +58,46 @@ pub fn command(matches: Option<&ArgMatches>) {
         );
     }
 
-    match function_language {
-        "rust" => {
-            assert_prereqs();
+    // match function_language {
+    //     "rust" => {
+    //         assert_prereqs();
+    //
+    //         std::fs::create_dir_all(format!(
+    //             "{}/src",
+    //             project
+    //                 .service_dir(String::from(default_service_name))
+    //                 .function_dir(String::from(default_function_name))
+    //                 .to_str()
+    //                 .unwrap()
+    //         ))
+    //         .unwrap();
+    //
+    //         let data = &mut Map::<String, Json>::new();
+    //         data.insert(
+    //             "function_name".to_string(),
+    //             to_json(default_function_name.to_string()),
+    //         );
+    //         write_documents(
+    //             &project
+    //                 .service_dir(String::from(default_service_name))
+    //                 .function_dir(String::from(default_function_name)),
+    //             (*RUST_FUNCTION_DOCUMENTS).clone().as_ref(),
+    //             data,
+    //         );
+    //     }
+    //     "ruby" => {
+    //         write_documents(
+    //             &project
+    //                 .service_dir(String::from(default_service_name))
+    //                 .function_dir(String::from(default_function_name)),
+    //             (*RUBY_FUNCTION_DOCUMENTS).clone().as_ref(),
+    //             &mut Map::<String, Json>::new(),
+    //         );
+    //     }
+    //     unknown => panic!("unsupported language: {}", unknown),
+    // }
 
-            std::fs::create_dir_all(format!(
-                "{}/src",
-                project
-                    .service_dir(String::from(default_service_name))
-                    .function_dir(String::from(default_function_name))
-                    .to_str()
-                    .unwrap()
-            ))
-            .unwrap();
-
-            let data = &mut Map::<String, Json>::new();
-            data.insert(
-                "function_name".to_string(),
-                to_json(default_function_name.to_string()),
-            );
-            write_documents(
-                &project
-                    .service_dir(String::from(default_service_name))
-                    .function_dir(String::from(default_function_name)),
-                (*RUST_FUNCTION_DOCUMENTS).clone().as_ref(),
-                data,
-            );
-        }
-        "ruby" => {
-            write_documents(
-                &project
-                    .service_dir(String::from(default_service_name))
-                    .function_dir(String::from(default_function_name)),
-                (*RUBY_FUNCTION_DOCUMENTS).clone().as_ref(),
-                &mut Map::<String, Json>::new(),
-            );
-        }
-        unknown => panic!("unsupported language: {}", unknown),
-    }
-
-    println!("\r\n✅  Done! Your project root is: {:?}", project.dir())
+    println!("\r\n✅  Done! Your project root is: {:?}", project.dir());
 }
 
 fn check_rust_prereqs() -> bool {

--- a/cli/src/commands/make.rs
+++ b/cli/src/commands/make.rs
@@ -1,10 +1,15 @@
 use clap::ArgMatches;
 use handlebars::to_json;
 use serde_json::value::{Map, Value as Json};
+use std::rc::Rc;
 
 use crate::projectfs::{locate_asml_manifest, Project};
-use crate::templates::project::{RUBY_FUNCTION_DOCUMENTS, RUST_FUNCTION_DOCUMENTS, SERVICE_DOCUMENTS};
+use crate::templates::project::{
+    RUBY_FUNCTION_DOCUMENTS, RUST_FUNCTION_DOCUMENTS, SERVICE_DOCUMENTS,
+};
 use crate::templates::write_documents;
+use crate::transpiler::toml::{asml, service};
+use crate::transpiler::toml::asml::ServiceRef;
 
 pub fn command(matches: Option<&ArgMatches>) {
     let matches = match matches {
@@ -16,10 +21,10 @@ pub fn command(matches: Option<&ArgMatches>) {
         Some(manifest) => manifest,
         None => panic!("could not find assemblylift.toml in tree"),
     };
-    let mut manifest_dir = manifest.1;
+    let mut manifest_dir = manifest.1.clone();
     manifest_dir.pop();
 
-    let project = Project::new(manifest.0.project.name, Some(manifest_dir));
+    let project = Project::new(manifest.0.project.name.clone(), Some(manifest_dir.clone()));
 
     let mut resource_type: Option<&str> = None;
     let mut resource_name: Option<&str> = None;
@@ -45,6 +50,10 @@ pub fn command(matches: Option<&ArgMatches>) {
                 .service_dir(String::from(resource_name.unwrap()))
                 .dir();
             write_documents(&path, (*SERVICE_DOCUMENTS).clone().as_ref(), data);
+
+            let mut manifest: asml::Manifest = manifest.0.clone();
+            manifest.add_service(resource_name.unwrap());
+            manifest.write(manifest_dir.clone()).expect("could not write assemblylift.toml");
         }
 
         Some("function") => {
@@ -54,6 +63,13 @@ pub fn command(matches: Option<&ArgMatches>) {
             if function_name.len() != 2 {
                 panic!("syntax is `make function <service>.<function>`")
             }
+
+            let service_dir = &*project.service_dir(function_name[0].into()).dir().clone();
+            let mut manifest_file = service_dir.clone();
+            manifest_file.push("service.toml");
+            let mut service_manifest = service::Manifest::read(&manifest_file).unwrap();
+            service_manifest.add_function(function_name[1], language);
+            service_manifest.write(service_dir.clone()).unwrap();
 
             match language {
                 "rust" => {
@@ -68,7 +84,11 @@ pub fn command(matches: Option<&ArgMatches>) {
                     let path = project
                         .service_dir(String::from(function_name[0]))
                         .function_dir(String::from(function_name[1]));
-                    write_documents(&path, (*RUBY_FUNCTION_DOCUMENTS).clone().as_ref(), &mut Map::<String, Json>::new());
+                    write_documents(
+                        &path,
+                        (*RUBY_FUNCTION_DOCUMENTS).clone().as_ref(),
+                        &mut Map::<String, Json>::new(),
+                    );
                 }
                 lang => panic!("function language `{}` is not supported", lang),
             }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod burn;
 pub mod cast;
 pub mod init;
 pub mod make;
+pub mod r#move;
 pub mod pack;
 pub mod push;
 pub mod user;

--- a/cli/src/commands/move.rs
+++ b/cli/src/commands/move.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use clap::ArgMatches;
 
 use crate::projectfs::{locate_asml_manifest, Project};
@@ -52,6 +54,8 @@ pub fn command(matches: Option<&ArgMatches>) {
                 .write(manifest_dir.clone())
                 .expect("could not write assemblylift.toml");
 
+            // TODO this (find & read a service toml) is duped a few times;
+            //      could be moved to a fn in ProjectFs
             let service_dir = &*project.service_dir(new_name.clone()).dir().clone();
             let mut service_manifest_file = service_dir.clone();
             service_manifest_file.push("service.toml");
@@ -60,7 +64,58 @@ pub fn command(matches: Option<&ArgMatches>) {
             service_manifest.write(service_dir.clone()).unwrap();
         }
 
-        Some("function") => unimplemented!("function move is not yet implemented"),
+        Some("function") => {
+            let old_name = resource_from.unwrap().to_string();
+            let old_name: Vec<&str> = old_name.split(".").collect();
+            let old_service = old_name[0];
+            let old_function = old_name[1];
+            let old_dir = &project
+                .service_dir(old_service.into())
+                .function_dir(old_function.into());
+
+            let new_name = resource_to.unwrap().to_string();
+            let new_name: Vec<&str> = new_name.split(".").collect();
+            let new_service = new_name[0];
+            let new_function = new_name[1];
+            let mut new_dir = old_dir.clone();
+            new_dir.pop();
+            new_dir.pop();
+            new_dir.push(String::from(new_service));
+            new_dir.push(String::from(new_function));
+
+            std::fs::rename(old_dir, new_dir).unwrap();
+
+            // rename function,
+            // if old_service != new_service then remove_function from old and add_function to new
+            let service_dir = &*project.service_dir(String::from(old_service)).dir().clone();
+            let mut service_manifest_file = service_dir.clone();
+            service_manifest_file.push("service.toml");
+            let mut service_manifest = service::Manifest::read(&service_manifest_file).unwrap();
+            service_manifest.rename_function(old_function, new_function);
+            if old_service != new_service {
+                let to_move = service_manifest
+                    .functions()
+                    .iter()
+                    .find(|f| f.name == new_function)
+                    .unwrap()
+                    .clone();
+                service_manifest.remove_function(new_function);
+
+                let new_service_dir = &*project.service_dir(String::from(new_service)).dir().clone();
+                let mut new_service_manifest_file = new_service_dir.clone();
+                new_service_manifest_file.push("service.toml");
+                let mut new_service_manifest = service::Manifest::read(&new_service_manifest_file).unwrap();
+                let mut functions = Vec::new();
+                for fun in new_service_manifest.functions().as_ref() {
+                    functions.push(fun.clone());
+                }
+                functions.push(to_move);
+                new_service_manifest.api.functions = Rc::new(functions);
+
+                new_service_manifest.write(new_service_dir.clone()).unwrap()
+            }
+            service_manifest.write(service_dir.clone()).unwrap();
+        }
 
         Some(_) => panic!("must specify either 'service' or 'function' as an argument to move"),
         None => panic!("must specify either 'service' or 'function' as an argument to move"),

--- a/cli/src/commands/move.rs
+++ b/cli/src/commands/move.rs
@@ -59,6 +59,7 @@ pub fn command(matches: Option<&ArgMatches>) {
             service_manifest.rename(&*new_name.clone());
             service_manifest.write(service_dir.clone()).unwrap();
         }
+
         Some("function") => unimplemented!("function move is not yet implemented"),
 
         Some(_) => panic!("must specify either 'service' or 'function' as an argument to move"),

--- a/cli/src/commands/move.rs
+++ b/cli/src/commands/move.rs
@@ -1,0 +1,67 @@
+use clap::ArgMatches;
+
+use crate::projectfs::{locate_asml_manifest, Project};
+use crate::transpiler::toml::{asml, service};
+
+pub fn command(matches: Option<&ArgMatches>) {
+    let matches = match matches {
+        Some(matches) => matches,
+        _ => panic!("could not get matches for make command"),
+    };
+
+    let manifest = match locate_asml_manifest() {
+        Some(manifest) => manifest,
+        None => panic!("could not find assemblylift.toml in tree"),
+    };
+    let mut manifest_dir = manifest.1.clone();
+    manifest_dir.pop();
+
+    let project = Project::new(manifest.0.project.name.clone(), Some(manifest_dir.clone()));
+
+    let mut resource_type: Option<&str> = None;
+    let mut resource_from: Option<&str> = None;
+    let mut resource_to: Option<&str> = None;
+    for el in matches.values_of("resource").unwrap() {
+        if resource_type.is_none() {
+            resource_type = Some(el);
+            continue;
+        }
+        if resource_from.is_none() {
+            resource_from = Some(el);
+            continue;
+        }
+        if resource_to.is_none() {
+            resource_to = Some(el);
+            continue;
+        }
+    }
+
+    match resource_type {
+        Some("service") => {
+            let old_name = resource_from.unwrap().to_string();
+            let old_dir = &*project.service_dir(old_name.clone()).dir().clone();
+            let new_name = resource_to.unwrap().to_string();
+            let mut new_dir = old_dir.clone();
+            new_dir.pop();
+            new_dir.push(new_name.clone());
+            std::fs::rename(old_dir, new_dir).unwrap();
+
+            let mut manifest: asml::Manifest = manifest.0.clone();
+            manifest.rename_service(&*old_name.clone(), &*new_name.clone());
+            manifest
+                .write(manifest_dir.clone())
+                .expect("could not write assemblylift.toml");
+
+            let service_dir = &*project.service_dir(new_name.clone()).dir().clone();
+            let mut service_manifest_file = service_dir.clone();
+            service_manifest_file.push("service.toml");
+            let mut service_manifest = service::Manifest::read(&service_manifest_file).unwrap();
+            service_manifest.rename(&*new_name.clone());
+            service_manifest.write(service_dir.clone()).unwrap();
+        }
+        Some("function") => unimplemented!("function move is not yet implemented"),
+
+        Some(_) => panic!("must specify either 'service' or 'function' as an argument to move"),
+        None => panic!("must specify either 'service' or 'function' as an argument to move"),
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,7 +2,7 @@ extern crate serde_json;
 
 use clap::{App, AppSettings, Arg, crate_version};
 
-use crate::commands::{bind, burn, cast, init, make, pack, push, user};
+use crate::commands::{bind, burn, cast, init, make, pack, push, r#move, user};
 
 mod archive;
 mod commands;
@@ -18,14 +18,14 @@ fn main() {
         .version(crate_version!())
         .subcommand(
             App::new("init")
-                .about("Initialize a basic AssemblyLift application")
-                .arg(
-                    Arg::with_name("language")
-                        .short("l")
-                        .long("lang")
-                        .default_value("rust")
-                        .takes_value(true),
-                )
+                .about("Initialize a new AssemblyLift application")
+                // .arg(
+                //     Arg::with_name("language")
+                //         .short("l")
+                //         .long("lang")
+                //         .default_value("rust")
+                //         .takes_value(true),
+                // )
                 .arg(
                     Arg::with_name("project_name")
                         .short("n")
@@ -48,6 +48,15 @@ fn main() {
                     .takes_value(true)
             )
         )
+        .subcommand(App::new("move")
+            .about("Rename a service or function, or move a function between services")
+            .after_help("RESOURCE SYNTAX:\n    asml move service <service-name> <new-name>\n    asml move function <service-name>.<function-name> <new-service>.<new-function>")
+            .arg(
+                Arg::with_name("resource")
+                    .multiple(true)
+                    .required(true)
+            )
+        )
         .subcommand(App::new("cast").about("Build the AssemblyLift application"))
         .subcommand(
             App::new("bind")
@@ -56,8 +65,13 @@ fn main() {
         )
         .subcommand(
             App::new("burn")
-                .about("Destroy all infrastructure created by 'bind'")
-                .after_help("Equivalent to 'terraform destroy'"),
+                .about("Destroy a service or function")
+                .after_help("RESOURCE SYNTAX:\n    asml burn service <service-name>\n    asml burn function <service-name>.<function-name>")
+                .arg(
+                    Arg::with_name("resource")
+                        .multiple(true)
+                        .required(true)
+                ),
         )
         .subcommand(
             App::new("pack")
@@ -115,6 +129,7 @@ fn main() {
         ("bind", matches) => bind::command(matches),
         ("burn", matches) => burn::command(matches),
         ("make", matches) => make::command(matches),
+        ("move", matches) => r#move::command(matches),
         ("pack", matches) => pack::command(matches),
         ("push", matches) => push::command(matches),
         ("user", matches) => user::command(matches),

--- a/cli/src/templates/project.rs
+++ b/cli/src/templates/project.rs
@@ -32,10 +32,6 @@ pub static ROOT_DOCUMENTS: Lazy<Arc<Vec<Document>>> = Lazy::new(|| Arc::new(Vec:
 
 static SERVICE_TOML: &str = r#"[service]
 name = "{{service_name}}"
-
-[[api.functions]]
-name = "my-function"
-language = {{function_language}}"
 "#;
 
 pub static SERVICE_DOCUMENTS: Lazy<Arc<Vec<Document>>> = Lazy::new(|| Arc::new(Vec::from([

--- a/cli/src/transpiler/context.rs
+++ b/cli/src/transpiler/context.rs
@@ -62,10 +62,6 @@ impl Context {
             for function in functions.as_ref() {
                 ctx_functions.push(Function {
                     name: function.name.clone(),
-                    provider: Rc::new(Provider {
-                        name: function.provider.name.clone(),
-                        options: function.provider.options.clone(),
-                    }),
                     registry: function.registry.clone().unwrap_or("ecr".to_string()),
                     service_name: service.name.clone(),
                     language: function.language.clone().unwrap_or("rust".to_string()),
@@ -289,7 +285,6 @@ pub struct Provider {
 
 pub struct Function {
     pub name: String,
-    pub provider: Rc<Provider>,
     pub registry: String,
     pub language: String,
     pub service_name: String,

--- a/cli/src/transpiler/toml.rs
+++ b/cli/src/transpiler/toml.rs
@@ -3,56 +3,107 @@ pub mod asml {
     use std::path::PathBuf;
     use std::rc::Rc;
 
-    use serde::Deserialize;
+    use serde::{Deserialize, Serialize};
 
     use crate::providers::Options;
 
-    #[derive(Deserialize)]
+    #[derive(Serialize, Deserialize, Clone, Debug)]
     pub struct Manifest {
         pub project: Project,
+        #[serde(skip_serializing_if = "Vec::is_empty", default = "Default::default")]
         pub services: Rc<Vec<Rc<ServiceRef>>>,
         pub terraform: Option<Terraform>,
         pub registries: Option<Vec<Registry>>,
     }
 
-    #[derive(Deserialize)]
+    #[derive(Serialize, Deserialize, Clone, Debug)]
     pub struct Project {
         pub name: String,
     }
 
-    #[derive(Deserialize)]
+    #[derive(Serialize, Deserialize, Clone, Debug)]
     pub struct Terraform {
         pub state_bucket_name: String,
         pub lock_table_name: String,
     }
 
     /* Represents a reference by name to a service (toml::service::Manifest) */
-    #[derive(Deserialize)]
+    #[derive(Serialize, Deserialize, Clone, Debug)]
     pub struct ServiceRef {
         pub name: String,
     }
 
-    #[derive(Deserialize)]
+    #[derive(Serialize, Deserialize, Clone, Debug)]
     pub struct Registry {
         pub host: String,
         pub options: Options,
     }
 
     impl Manifest {
-        pub fn read(path: &PathBuf) -> Result<Self, io::Error> {
-            match std::fs::read_to_string(path) {
+        pub fn read(file: &PathBuf) -> Result<Self, io::Error> {
+            match std::fs::read_to_string(file) {
                 Ok(contents) => Ok(Self::from(contents)),
                 Err(why) => Err(io::Error::new(io::ErrorKind::Other, why.to_string())),
             }
         }
+
+        pub fn write(&self, mut path: PathBuf) -> Result<(), io::Error> {
+            path.push("assemblylift.toml");
+            let contents = Into::<String>::into(self.clone());
+            std::fs::write(path, contents)
+        }
+
+        pub fn add_service(&mut self, resource_name: &str) {
+            let mut services = Vec::new();
+            for svc in self.services.as_ref() {
+                services.push(svc.clone());
+            }
+            services.push(Rc::new(ServiceRef {
+                name: resource_name.to_string(),
+            }));
+            self.services = Rc::new(services);
+        }
+
+        pub fn remove_service(&mut self, resource_name: &str) {
+            let mut services = Vec::new();
+            for svc in self
+                .services
+                .as_ref()
+                .iter()
+                .filter(|s| s.name != resource_name)
+            {
+                services.push(svc.clone());
+            }
+            self.services = Rc::new(services);
+        }
+
+        pub fn rename_service(&mut self, old_name: &str, new_name: &str) {
+            let mut services = Vec::new();
+            for svc in self.services.as_ref() {
+                if svc.name == old_name {
+                    services.push(Rc::new(ServiceRef {
+                        name: new_name.into(),
+                    }));
+                } else {
+                    services.push(svc.clone());
+                }
+            }
+            self.services = Rc::new(services);
+        }
     }
-    
+
     impl From<String> for Manifest {
         fn from(string: String) -> Self {
             match toml::from_str(&string) {
                 Ok(manifest) => manifest,
-                Err(why) => panic!("error parsing ServiceManifest: {}", why.to_string()),
+                Err(why) => panic!("error parsing Manifest: {}", why.to_string()),
             }
+        }
+    }
+
+    impl Into<String> for Manifest {
+        fn into(self) -> String {
+            toml::to_string(&self).expect("unable to serialize TOML")
         }
     }
 }
@@ -63,33 +114,39 @@ pub mod service {
     use std::rc::Rc;
     use std::sync::Arc;
 
-    use serde::Deserialize;
+    use serde::{Deserialize, Serialize};
 
     use crate::transpiler::StringMap;
 
-    #[derive(Deserialize)]
+    #[derive(Serialize, Deserialize, Clone)]
     pub struct Manifest {
         service: Rc<Service>,
+        #[serde(default)]
         api: Api,
         iomod: Rc<Option<Iomod>>,
     }
 
     impl Manifest {
-        pub fn read(path: &PathBuf) -> Result<Self, io::Error> {
-            match std::fs::read_to_string(path) {
+        pub fn read(file: &PathBuf) -> Result<Self, io::Error> {
+            match std::fs::read_to_string(file) {
                 Ok(contents) => Ok(Self::from(contents)),
                 Err(why) => Err(io::Error::new(io::ErrorKind::Other, why.to_string())),
             }
         }
 
+        pub fn write(&self, mut path: PathBuf) -> Result<(), io::Error> {
+            path.push("service.toml");
+            std::fs::write(path, Into::<String>::into(self.clone()))
+        }
+
         pub fn service(&self) -> Rc<Service> {
             self.service.clone()
         }
-        
+
         pub fn functions(&self) -> Rc<Functions> {
             self.api.functions.clone()
         }
-        
+
         pub fn iomods(&self) -> Rc<Iomods> {
             match self.iomod.as_ref() {
                 Some(iomod) => iomod.dependencies.clone(),
@@ -103,6 +160,46 @@ pub mod service {
                 None => Rc::new(Authorizers::new()),
             }
         }
+
+        pub fn rename(&mut self, new_name: &str) {
+            let svc = self.service.clone();
+            let new_svc = Service {
+                name: new_name.to_string(),
+                provider: svc.provider.clone(),
+            };
+            self.service = Rc::new(new_svc);
+        }
+
+        pub fn add_function(&mut self, resource_name: &str, language: &str) {
+            let mut functions = Vec::new();
+            for fun in self.functions().as_ref() {
+                functions.push(fun.clone());
+            }
+            let fun = Function {
+                name: resource_name.to_string(),
+                registry: None,
+                language: Some(language.into()),
+                http: Rc::new(None),
+                authorizer_id: None,
+                timeout_seconds: None,
+                size_mb: None,
+            };
+            functions.push(fun);
+            self.api.functions = Rc::new(functions);
+        }
+
+        pub fn remove_function(&mut self, resource_name: &str) {
+            let mut functions = Vec::new();
+            for svc in self
+                .functions()
+                .as_ref()
+                .iter()
+                .filter(|f| f.name != resource_name)
+            {
+                functions.push(svc.clone());
+            }
+            self.api.functions = Rc::new(functions);
+        }
     }
 
     impl From<String> for Manifest {
@@ -114,18 +211,24 @@ pub mod service {
         }
     }
 
+    impl Into<String> for Manifest {
+        fn into(self) -> String {
+            toml::to_string(&self).expect("unable to serialize TOML")
+        }
+    }
+
     pub type Functions = Vec<Function>;
     pub type Iomods = Vec<Dependency>;
     pub type Authorizers = Vec<HttpAuth>;
 
-    #[derive(Deserialize)]
+    #[derive(Serialize, Deserialize, Clone)]
     pub struct Provider {
         pub name: String,
-        #[serde(default)]
+        #[serde(skip_serializing_if = "StringMap::is_empty", default)]
         pub options: Arc<StringMap<String>>,
     }
 
-    #[derive(Deserialize)]
+    #[derive(Serialize, Deserialize, Clone)]
     pub struct Service {
         pub name: String,
         #[serde(default)]
@@ -141,13 +244,13 @@ pub mod service {
         }
     }
 
-    #[derive(Deserialize)]
+    #[derive(Serialize, Deserialize, Clone, Default)]
     pub struct Api {
         pub functions: Rc<Vec<Function>>,
         pub authorizers: Option<Rc<Vec<HttpAuth>>>,
     }
 
-    #[derive(Deserialize)]
+    #[derive(Serialize, Deserialize, Clone)]
     pub struct HttpAuth {
         pub id: String,
         pub auth_type: String,
@@ -156,17 +259,15 @@ pub mod service {
         pub issuer: Rc<Option<String>>,
     }
 
-    #[derive(Deserialize)]
+    #[derive(Serialize, Deserialize, Clone)]
     pub struct HttpFunction {
         pub verb: String,
         pub path: String,
     }
 
-    #[derive(Deserialize)]
+    #[derive(Serialize, Deserialize, Clone)]
     pub struct Function {
         pub name: String,
-        #[serde(default)]
-        pub provider: Rc<Provider>,
         pub registry: Option<String>,
         pub language: Option<String>,
 
@@ -177,12 +278,12 @@ pub mod service {
         pub size_mb: Option<u16>,
     }
 
-    #[derive(Deserialize)]
+    #[derive(Serialize, Deserialize, Clone)]
     pub struct Iomod {
         pub dependencies: Rc<Vec<Dependency>>,
     }
 
-    #[derive(Clone, Deserialize)]
+    #[derive(Serialize, Deserialize, Clone)]
     pub struct Dependency {
         pub version: String,
         pub coordinates: String,

--- a/cli/src/transpiler/toml.rs
+++ b/cli/src/transpiler/toml.rs
@@ -122,7 +122,7 @@ pub mod service {
     pub struct Manifest {
         service: Rc<Service>,
         #[serde(default)]
-        api: Api,
+        pub api: Api, // FIXME not pub
         iomod: Rc<Option<Iomod>>,
     }
 
@@ -198,6 +198,23 @@ pub mod service {
             {
                 functions.push(svc.clone());
             }
+            self.api.functions = Rc::new(functions);
+        }
+
+        pub fn rename_function(&mut self, old_name: &str, new_name: &str) {
+            let mut to_rename = self
+                .functions()
+                .iter()
+                .find(|f| f.name == old_name)
+                .unwrap()
+                .clone();
+            to_rename.name = new_name.into();
+            self.remove_function(old_name);
+            let mut functions = Vec::new();
+            for fun in self.functions().as_ref() {
+                functions.push(fun.clone());
+            }
+            functions.push(to_rename);
             self.api.functions = Rc::new(functions);
         }
     }


### PR DESCRIPTION
This PR is an overhaul of the `asml` commands for interacting with services & functions in a project.

Changes:
* **`burn`**: instead of mapping to `terraform destroy`, `burn` now accepts the same arguments as `make` and allows you to remove a function or an entire service. This will remove the entries from the project TOML as well as delete the directories.
* **`make`**: will now update the relevant TOML when a new service or function is created
* **`move`**: is a new command which allows you to rename service, rename a function, and/or move a function between services. Accepts the same arguments as `burn` and `make`.
* **`init`**: no longer creates a function in the initial service

For example:
`asml move function web.server www.server`
will migrate the `server` function from service `web` to service `www`.

Changes are not reflected in infrastructure until running `asml cast`.