### PR TITLE
Deploy large Lambda function archives to S3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,7 @@ dependencies = [
  "wasmer",
  "wasmer-compiler",
  "wasmer-compiler-cranelift",
+ "wasmer-compiler-singlepass",
  "wasmer-engine-universal",
  "z85",
  "zip 0.6.2",
@@ -1050,6 +1051,32 @@ name = "dyn-clone"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d07a982d1fb29db01e5a59b1918e03da4df7297eaeee7686ac45542fd4e59c8"
+
+[[package]]
+name = "dynasm"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add9a102807b524ec050363f09e06f1504214b0e1c7797f64261c891022dce8b"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dynasmrt"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fba5a42bd76a17cad4bfa00de168ee1cbfa06a5e8ce992ae880218c05641a9"
+dependencies = [
+ "byteorder",
+ "dynasm",
+ "memmap2",
+]
 
 [[package]]
 name = "either"
@@ -4718,6 +4745,25 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "tracing",
+ "wasmer-compiler",
+ "wasmer-types",
+]
+
+[[package]]
+name = "wasmer-compiler-singlepass"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ca2a35204d8befa85062bc7aac259a8db8070b801b8a783770ba58231d729e"
+dependencies = [
+ "byteorder",
+ "dynasm",
+ "dynasmrt",
+ "gimli",
+ "lazy_static",
+ "loupe",
+ "more-asserts",
+ "rayon",
+ "smallvec",
  "wasmer-compiler",
  "wasmer-types",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,7 @@ name = "assemblylift-cli"
 version = "0.4.0-alpha.5"
 dependencies = [
  "asml-iomod-registry-common",
+ "assemblylift-core",
  "assemblylift-core-iomod",
  "base64 0.13.0",
  "bytes 1.1.0",
@@ -134,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "assemblylift-core"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "anyhow",
  "assemblylift-core-io-common 0.3.0",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -40,7 +40,8 @@ wasmer-compiler-cranelift = "2.1.1"
 wasmer-compiler-singlepass = "2.1.1"
 wasmer-engine-universal = "2.1.1"
 
-assemblylift_core_iomod = { version = "0.4.0-alpha.0", package = "assemblylift-core-iomod", path = "../core/iomod" }
+assemblylift-core = { version = "0.4.0-alpha.3", path = "../core" }
+assemblylift-core-iomod = { version = "0.4.0-alpha.0", path = "../core/iomod" }
 
 registry_common = { version = "0.1", package = "asml-iomod-registry-common" }
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -37,6 +37,7 @@ wasmer-compiler = "2.1.1"
 wasmer-compiler-cranelift = "2.1.1"
 #wasmer-compiler-llvm = "1.0"
 #wasmer-engine-native = "1.0"
+wasmer-compiler-singlepass = "2.1.1"
 wasmer-engine-universal = "2.1.1"
 
 assemblylift_core_iomod = { version = "0.4.0-alpha.0", package = "assemblylift-core-iomod", path = "../core/iomod" }

--- a/cli/src/commands/cast/mod.rs
+++ b/cli/src/commands/cast/mod.rs
@@ -82,42 +82,9 @@ pub fn command(matches: Option<&ArgMatches>) {
                 format!("./net/services/{}/{}", service_name, function_name);
 
             let wasm_path = lang::compile(project.clone(), &service_name, function);
-            let is_wasmu = wasm_path.extension().unwrap_or("wasm".as_ref()).eq("wasmu");
-            let module_file_path = match is_wasmu {
-                false => {
-                    // TODO compiler configuration
-                    let file_path = format!("{}u", wasm_path.to_str().unwrap());
-                    println!("Precompiling WASM to {}...", file_path.clone());
-                    let compiler = Cranelift::default();
-                    let triple = Triple::from_str("x86_64-unknown-unknown").unwrap();
-                    let mut cpuid = CpuFeature::set();
-                    cpuid.insert(CpuFeature::SSE2); // required for x86
-                    let store = Store::new(&/*Native*/Universal::new(compiler)
-                        .target(Target::new(triple, cpuid))
-                        .engine()
-                    );
-
-                    let wasm_bytes = match fs::read(wasm_path.clone()) {
-                        Ok(bytes) => bytes,
-                        Err(err) => panic!("{}", err.to_string()),
-                    };
-                    let module = Module::new(&store, wasm_bytes).unwrap();
-                    let module_bytes = module.serialize().unwrap();
-                    let mut module_file = match fs::File::create(file_path.clone()) {
-                        Ok(file) => file,
-                        Err(err) => panic!("{}", err.to_string()),
-                    };
-                    println!("📄 > Wrote {}", &file_path);
-                    module_file.write_all(&module_bytes).unwrap();
-
-                    PathBuf::from(file_path)
-                }
-
-                true => wasm_path
-            };
 
             // TODO not needed w/ container functions
-            let mut function_dirs = vec![module_file_path];
+            let mut function_dirs = vec![wasm_path];
             if let Some("ruby") = function.language.clone().as_deref() {
                 function_dirs.push(PathBuf::from(format!("{}/rubysrc", &function_artifact_path)));
             }

--- a/cli/src/commands/cast/ruby.rs
+++ b/cli/src/commands/cast/ruby.rs
@@ -54,12 +54,12 @@ pub fn compile(project: Rc<Project>, service_name: &str, function: &Function) ->
     }
 
     let copy_from = format!(
-        "{}/ruby-wasm32-wasi/usr/local/bin/ruby.wasmu",
-        // "{}/ruby-wasm32-wasi/usr/local/bin/ruby",
+        // "{}/ruby-wasm32-wasi/usr/local/bin/ruby.wasmu",
+        "{}/ruby-wasm32-wasi/usr/local/bin/ruby",
         service_artifact_path
     );
-    let copy_to = format!("{}/ruby.wasmu", function_artifact_path.clone());
-    // let copy_to = format!("{}/ruby.wasm", function_artifact_path.clone());
+    // let copy_to = format!("{}/ruby.wasmu", function_artifact_path.clone());
+    let copy_to = format!("{}/ruby.wasm", function_artifact_path.clone());
     let copy_result = std::fs::copy(copy_from.clone(), copy_to.clone());
     if copy_result.is_err() {
         println!(

--- a/cli/src/commands/cast/ruby.rs
+++ b/cli/src/commands/cast/ruby.rs
@@ -54,11 +54,12 @@ pub fn compile(project: Rc<Project>, service_name: &str, function: &Function) ->
     }
 
     let copy_from = format!(
-        // "{}/ruby-wasm32-wasi/usr/local/bin/ruby.wasmu",
-        "{}/ruby-wasm32-wasi/usr/local/bin/ruby",
+        "{}/ruby-wasm32-wasi/usr/local/bin/ruby.wasmu",
+        // "{}/ruby-wasm32-wasi/usr/local/bin/ruby",
         service_artifact_path
     );
     let copy_to = format!("{}/ruby.wasmu", function_artifact_path.clone());
+    // let copy_to = format!("{}/ruby.wasm", function_artifact_path.clone());
     let copy_result = std::fs::copy(copy_from.clone(), copy_to.clone());
     if copy_result.is_err() {
         println!(

--- a/cli/src/commands/cast/rust.rs
+++ b/cli/src/commands/cast/rust.rs
@@ -41,7 +41,6 @@ pub fn compile(project: Rc<Project>, service_name: &str, function: &Function) ->
         std::process::exit(-1);
     }
 
-    // FIXME this should use the binary name in Cargo.toml if present
     let copy_from = format!(
         "{}/target/{}/{}/{}.wasm",
         project

--- a/cli/src/commands/cast/rust.rs
+++ b/cli/src/commands/cast/rust.rs
@@ -2,6 +2,8 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::rc::Rc;
 
+use assemblylift_core::wasm;
+
 use crate::projectfs::Project;
 use crate::transpiler::toml::service::Function;
 
@@ -60,5 +62,6 @@ pub fn compile(project: Rc<Project>, service_name: &str, function: &Function) ->
         println!("ERROR COPY from={} to={}", copy_from.clone(), copy_to.clone());
         panic!("{:?}", copy_result.err());
     }
-    PathBuf::from(copy_to)
+
+    wasm::precompile(PathBuf::from(copy_to)).unwrap()
 }

--- a/cli/src/commands/pack.rs
+++ b/cli/src/commands/pack.rs
@@ -39,5 +39,5 @@ fn command_iomod(matches: Option<&ArgMatches>) {
 
     let out_path = matches.value_of("out").unwrap(); // unwrap: this arg is required
 
-    archive::zip_dir(cwd, out_path, vec![]).expect("zip_dir failed during pack");
+    archive::zip_dirs(vec![cwd], out_path, vec![]).expect("zip_dir failed during pack");
 }

--- a/cli/src/providers/aws_lambda.rs
+++ b/cli/src/providers/aws_lambda.rs
@@ -1,17 +1,19 @@
 use std::fs;
+use std::fs::File;
 use std::io::Read;
+use std::os::unix::fs::MetadataExt;
 use std::path::Path;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use handlebars::{Handlebars, to_json};
+use handlebars::{to_json, Handlebars};
 use registry_common::models::GetIomodAtResponse;
 use serde::Serialize;
 
 use crate::archive;
-use crate::providers::{Options, Provider, ProviderError, render_string_list};
-use crate::transpiler::{Artifact, Bindable, Castable, CastError, ContentType, context, Template};
-use crate::transpiler::context::Context;
+use crate::providers::{render_string_list, Options, Provider, ProviderError};
+use crate::transpiler::context::{Context, Function};
+use crate::transpiler::{context, Artifact, Bindable, CastError, Castable, ContentType, Template};
 
 pub struct AwsLambdaProvider {
     options: Arc<Options>,
@@ -96,12 +98,28 @@ impl AwsLambdaProvider {
 
     pub fn cast_ruby(ctx: Rc<Context>, service_name: &str) -> Result<(), CastError> {
         let project_path = ctx.project.path.clone();
-        let ruby_dir = format!("{}/net/services/{}/ruby-wasm32-wasi", project_path, service_name);
+        let ruby_dir = format!(
+            "{}/net/services/{}/ruby-wasm32-wasi",
+            project_path, service_name
+        );
         archive::zip_dir(
             ruby_dir.into(),
             format!("./.asml/runtime/{}-ruby.zip", &service_name),
             vec!["ruby.wasmu", "ruby"],
-        ).map_err(|_| CastError("could not zip ruby env directory".into()))
+        )
+        .map_err(|_| CastError("could not zip ruby env directory".into()))
+    }
+
+    pub fn is_function_large(ctx: Rc<Context>, f: &Function) -> bool {
+        let project_path = ctx.project.path.clone();
+        let artifact_path = format!(
+            "{}/net/services/{}/{}/{}.zip",
+            &project_path,
+            f.service_name.clone(),
+            f.name.clone(),
+            f.name.clone()
+        );
+        File::open(artifact_path).unwrap().metadata().unwrap().size() > (50 * 1024 * 1024)
     }
 }
 
@@ -180,13 +198,22 @@ impl Castable for LambdaService {
 
         AwsLambdaProvider::cast_iomods(ctx.clone(), &name).unwrap();
         let mut has_ruby_layer = false;
-        if ctx.functions.iter().find(|f| f.language == "ruby").is_some() {
+        if ctx
+            .functions
+            .iter()
+            .find(|f| f.language == "ruby")
+            .is_some()
+        {
             AwsLambdaProvider::cast_ruby(ctx.clone(), &name)?;
             has_ruby_layer = true;
         }
-
-        let use_apigw = ctx.functions.iter().find(|f| f.http.is_some()).is_some();
         let has_iomods_layer = ctx.iomods.len() > 0;
+        let has_large_payloads = ctx
+            .functions
+            .iter()
+            .find(|f| AwsLambdaProvider::is_function_large(ctx.clone(), f))
+            .is_some();
+        let use_apigw = ctx.functions.iter().find(|f| f.http.is_some()).is_some();
 
         let authorizers: Vec<ServiceAuthData> = ctx
             .authorizers
@@ -216,9 +243,11 @@ impl Castable for LambdaService {
             use_apigw,
             has_iomods_layer,
             has_ruby_layer,
+            has_large_payloads,
             authorizers,
             options: self.options.clone(),
-        }.render();
+        }
+        .render();
 
         let function_subprovider = LambdaFunction {
             options: self.options.clone(),
@@ -315,6 +344,7 @@ impl Castable for LambdaFunction {
                     handler_name: match function.language.as_str() {
                         "rust" => format!("{}.wasm.bin", function.name.clone()),
                         "ruby" => "ruby.wasmu".into(),
+                        // "ruby" => "ruby.wasm".into(),
                         _ => "handler".into(),
                     },
                     runtime_layer: format!(
@@ -335,6 +365,7 @@ impl Castable for LambdaFunction {
                         )),
                         _ => None,
                     },
+                    large_payload: AwsLambdaProvider::is_function_large(ctx.clone(), function),
                     size: function.size,
                     timeout: function.timeout,
                     http: match &function.http {
@@ -395,6 +426,7 @@ struct ServiceTemplate {
     layer_name: String,
     has_iomods_layer: bool,
     has_ruby_layer: bool,
+    has_large_payloads: bool,
     use_apigw: bool,
     authorizers: Vec<ServiceAuthData>,
     options: Arc<Options>,
@@ -465,6 +497,15 @@ resource aws_apigatewayv2_stage {{service_name}}_default_stage {
     }{{/if}}
 }{{/each}}
 
+{{#if has_large_payloads}}resource aws_s3_bucket asml_{{service_name}}_functions {
+    provider = aws.{{project_name}}
+    bucket   = "asml-${local.project_name}-{{service_name}}-functions"
+}
+resource aws_s3_bucket_acl functions {
+    provider = aws.{{project_name}}
+    bucket   = aws_s3_bucket.asml_{{service_name}}_functions.id
+    acl      = "private"
+}{{/if}}
 "#
     }
 }
@@ -477,6 +518,7 @@ pub struct FunctionTemplate {
     pub runtime_layer: String,
     pub iomods_layer: Option<String>,
     pub ruby_layer: Option<String>,
+    pub large_payload: bool,
     pub http: Option<HttpData>,
     pub auth: Option<FunctionAuthData>,
     pub size: u16,
@@ -495,6 +537,13 @@ impl Template for FunctionTemplate {
     fn tmpl() -> &'static str {
         r#"# Begin function `{{function_name}}` (in `{{service_name}}`)
 
+{{#if large_payload}}resource aws_s3_object asml_{{service_name}}_{{function_name}} {
+    key    = "{{function_name}}.zip"
+    bucket = aws_s3_bucket.asml_{{service_name}}_functions.id
+    source = "${local.project_path}/net/services/{{service_name}}/{{function_name}}/{{function_name}}.zip"
+    etag   = filemd5("${local.project_path}/net/services/{{service_name}}/{{function_name}}/{{function_name}}.zip")
+}{{/if}}
+
 resource aws_lambda_function asml_{{service_name}}_{{function_name}} {
     provider = aws.{{project_name}}
 
@@ -502,9 +551,15 @@ resource aws_lambda_function asml_{{service_name}}_{{function_name}} {
     role          = aws_iam_role.{{service_name}}_{{function_name}}_lambda_iam_role.arn
     runtime       = "provided"
     handler       = "{{handler_name}}"
-    filename      = "${local.project_path}/net/services/{{service_name}}/{{function_name}}/{{function_name}}.zip"
     timeout       = {{timeout}}
     memory_size   = {{size}}
+
+    {{#if large_payload}}
+    s3_key    = "{{../function_name}}.zip"
+    s3_bucket = aws_s3_bucket.asml_{{../service_name}}_functions.id
+    {{else}}
+    filename  = "${local.project_path}/net/services/{{../service_name}}/{{../function_name}}/{{../function_name}}.zip"
+    {{/if}}
 
     {{#if ruby_layer}}environment {
       variables = {

--- a/cli/src/providers/k8s.rs
+++ b/cli/src/providers/k8s.rs
@@ -209,7 +209,7 @@ impl Castable for KubernetesFunction {
                     function_name: function.name.clone(),
                     service_name: service.clone(),
                     handler_name: match function.language.as_str() {
-                        "rust" => format!("{}.wasm.bin", function.name.clone()),
+                        "rust" => format!("{}.wasmu", function.name.clone()),
                         "ruby" => "ruby.wasmu".into(),
                         _ => "handler".into(),
                     },

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assemblylift-core"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 description = "AssemblyLift core library"
 authors = ["Akkoro and the AssemblyLift contributors <assemblylift@akkoro.io>"]
 edition = "2018"

--- a/core/src/wasm.rs
+++ b/core/src/wasm.rs
@@ -43,7 +43,7 @@ where
     let compiler = Cranelift::default();
     let store = Store::new(&Universal::new(compiler).engine());
     Ok((
-        unsafe { wasmer::Module::deserialize(&store, module_bytes) }
+        unsafe { Module::deserialize(&store, module_bytes) }
             .expect(&format!("could not load wasm from bytes")),
         store,
     ))

--- a/core/src/wasm.rs
+++ b/core/src/wasm.rs
@@ -1,9 +1,9 @@
+use std::io::Write;
+use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::Arc;
 
-use wasmer::{
-    ChainableNamedResolver, Cranelift, Function, ImportObject, imports, Instance,
-    InstantiationError, Module, NamedResolverChain, Store, Universal,
-};
+use wasmer::{ChainableNamedResolver, CpuFeature, Cranelift, Function, ImportObject, imports, Instance, InstantiationError, Module, NamedResolverChain, Store, Target, Triple, Universal};
 use wasmer_wasi::WasiState;
 
 use assemblylift_core_iomod::registry::RegistryTx;
@@ -122,4 +122,41 @@ pub fn new_instance(
     import_object: Resolver,
 ) -> Result<Instance, InstantiationError> {
     Instance::new(&module, &import_object)
+}
+
+pub fn precompile(module_path: PathBuf) -> Result<PathBuf, &'static str> {
+    // TODO compiler configuration
+    let is_wasmu = module_path.extension().unwrap_or("wasm".as_ref()).eq("wasmu");
+    match is_wasmu {
+        false => {
+            let file_path = format!("{}u", module_path.as_path().display().to_string());
+            println!("Precompiling WASM to {}...", file_path.clone());
+
+            let compiler = Cranelift::default();
+            let triple = Triple::from_str("x86_64-unknown-unknown").unwrap();
+            let mut cpuid = CpuFeature::set();
+            cpuid.insert(CpuFeature::SSE2); // required for x86
+            let store = Store::new(&/*Native*/Universal::new(compiler)
+                .target(Target::new(triple, cpuid))
+                .engine()
+            );
+
+            let wasm_bytes = match std::fs::read(module_path.clone()) {
+                Ok(bytes) => bytes,
+                Err(err) => panic!("{}", err.to_string()),
+            };
+            let module = Module::new(&store, wasm_bytes).unwrap();
+            let module_bytes = module.serialize().unwrap();
+            let mut module_file = match std::fs::File::create(file_path.clone()) {
+                Ok(file) => file,
+                Err(err) => panic!("{}", err.to_string()),
+            };
+            println!("📄 > Wrote {}", &file_path);
+            module_file.write_all(&module_bytes).unwrap();
+
+            Ok(PathBuf::from(file_path))
+        }
+
+        true => Ok(module_path)
+    }
 }

--- a/core/src/wasm.rs
+++ b/core/src/wasm.rs
@@ -75,7 +75,7 @@ where
         "ruby-lambda" => WasiState::new(module_name.clone())
             .arg("/src/handler.rb")
             .env("RUBY_PLATFORM", "wasm32-wasi")
-            .map_dir("/src", "/opt/ruby-wasm32-wasi/src")
+            .map_dir("/src", format!("{}/rubysrc", std::env::var("LAMBDA_TASK_ROOT").unwrap()))
             .expect("could not preopen `src` directory")
             .map_dir("/usr", "/opt/ruby-wasm32-wasi/usr")
             .expect("could not map ruby fs")

--- a/runtimes/aws-lambda/host/src/main.rs
+++ b/runtimes/aws-lambda/host/src/main.rs
@@ -107,9 +107,8 @@ async fn main() {
 
     let module_path = env::var("LAMBDA_TASK_ROOT").unwrap();
     let handler_name = env::var("_HANDLER").unwrap();
-    let coords = handler_name.split(".").collect::<Vec<&str>>();
-    // let module_name = format!("{}.wasm.bin", coords[0]);
-    let function_name = String::from(coords[0]);
+    let parts = handler_name.split(".").collect::<Vec<&str>>();
+    let function_name = String::from(parts[0]);
 
     let (status_sender, _status_receiver) = bounded::<()>(1);
 


### PR DESCRIPTION
Archives larger than 50MB (the direct upload limit as of writing) are now deployed to an S3 bucket. One bucket is created per service.

The `ruby` binary is now precompiled to Wasmer Universal per-service if not found on the first `cast` of a Ruby function.