### PR TITLE
Add flag enabling service DNS names mapped to root

### DIFF
--- a/cli/src/providers/gloo/mod.rs
+++ b/cli/src/providers/gloo/mod.rs
@@ -63,7 +63,15 @@ impl ApiProvider {
             .as_ref()
             .unwrap_or(&"local".to_string())
             .clone();
-        format!("{}.{}.{}", name, project_name, domain_name)
+        let domain = ctx
+            .domains
+            .iter()
+            .find(|&d| &d.dns_name == &domain_name)
+            .unwrap();
+        match domain.map_to_root {
+            true => format!("{}.{}", name, domain_name),
+            false => format!("{}.{}.{}", name, project_name, domain_name),
+        }
     }
 }
 

--- a/cli/src/providers/route53/mod.rs
+++ b/cli/src/providers/route53/mod.rs
@@ -7,10 +7,10 @@ use itertools::Itertools;
 use jsonpath_lib::Selector;
 use serde::Serialize;
 
-use crate::providers::{Options, Provider, ProviderError, AWS_LAMBDA_PROVIDER_NAME, KUBERNETES_PROVIDER_NAME, ROUTE53_PROVIDER_NAME};
+use crate::providers::{AWS_LAMBDA_PROVIDER_NAME, KUBERNETES_PROVIDER_NAME, Options, Provider, ProviderError, ROUTE53_PROVIDER_NAME};
 use crate::tools::kubectl::KubeCtl;
+use crate::transpiler::{Artifact, Bindable, Bootable, Castable, CastError, ContentType, Template};
 use crate::transpiler::context::Context;
-use crate::transpiler::{Artifact, Bindable, Bootable, CastError, Castable, ContentType, Template};
 
 pub struct DnsProvider {
     /// aws_access_key_id, aws_secret_access_key_secret_name, aws_region
@@ -171,15 +171,15 @@ data aws_route53_zone {{this.name_snaked}} {
 {{#if this.is_apigw_target}}
 resource aws_acm_certificate {{this.name}} {
   provider    = aws.{{../../project_name}}-r53
-  {{#if this.map_to_root}}domain_name = "{{this.name}}.{{../../project_name}}.{{../name}}"
-  {{else}}domain_name = "{{this.name}}.{{../name}}"{{/if}}
+  {{#unless this.map_to_root}}domain_name = "{{this.name}}.{{../../project_name}}.{{../name}}"
+  {{else}}domain_name = "{{this.name}}.{{../name}}"{{/unless}}
   validation_method = "DNS"
 }
 
 resource aws_apigatewayv2_domain_name {{this.name}} {
   provider    = aws.{{../../project_name}}-r53
-  {{#if this.map_to_root}}domain_name = "{{this.name}}.{{../../project_name}}.{{../name}}"
-  {{else}}domain_name = "{{this.name}}.{{../name}}"{{/if}}
+  {{#unless this.map_to_root}}domain_name = "{{this.name}}.{{../../project_name}}.{{../name}}"
+  {{else}}domain_name = "{{this.name}}.{{../name}}"{{/unless}}
 
   domain_name_configuration {
     certificate_arn = aws_acm_certificate.{{this.name}}.arn
@@ -222,7 +222,8 @@ resource aws_apigatewayv2_api_mapping {{this.name}} {
 resource aws_route53_record {{this.name}} {
   provider = aws.{{../../project_name}}-r53
   zone_id  = data.aws_route53_zone.{{../name_snaked}}.zone_id
-  name     = "{{this.name}}.{{../../project_name}}"
+  {{#unless this.map_to_root}}name     = "{{this.name}}.{{../../project_name}}"
+  {{else}}name     = "{{this.name}}"{{/unless}}
   type     = "A"
   {{#unless this.is_apigw_target}}ttl      = "300"
   records  = {{{this.target}}}

--- a/cli/src/transpiler/context.rs
+++ b/cli/src/transpiler/context.rs
@@ -49,6 +49,7 @@ impl Context {
             .iter()
             .map(|d| Domain {
                 dns_name: d.dns_name.clone(),
+                map_to_root: d.map_to_root,
                 provider: Rc::new(Provider {
                     name: d.provider.name.clone(),
                     options: d.provider.options.clone(),
@@ -311,6 +312,7 @@ pub struct Registry {
 
 pub struct Domain {
     pub dns_name: String,
+    pub map_to_root: bool,
     pub provider: Rc<Provider>,
 }
 

--- a/cli/src/transpiler/toml.rs
+++ b/cli/src/transpiler/toml.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 use crate::transpiler::StringMap;
 
@@ -57,6 +57,7 @@ pub mod asml {
     #[derive(Serialize, Deserialize, Clone, Debug)]
     pub struct Domain {
         pub dns_name: String,
+        #[serde(default)]
         pub map_to_root: bool,
         pub provider: Provider,
     }

--- a/cli/src/transpiler/toml.rs
+++ b/cli/src/transpiler/toml.rs
@@ -57,6 +57,7 @@ pub mod asml {
     #[derive(Serialize, Deserialize, Clone, Debug)]
     pub struct Domain {
         pub dns_name: String,
+        pub map_to_root: bool,
         pub provider: Provider,
     }
 


### PR DESCRIPTION
Specifying `map_to_root = true` for a domain will cause its services to map to `{service_name}.{domain_name}` instead of `{service_name}.{project_name}.{domain_name}`.

```toml
[[domains]]
dns_name = "example.com"
map_to_root = true # defaults to false if omitted

[[services]]
name = "mysvc" # will be at https://mysvc.example.com
```