### PR TITLE
Fix Gloo API provider if no domains declared

### DIFF
--- a/cli/src/providers/gloo/mod.rs
+++ b/cli/src/providers/gloo/mod.rs
@@ -63,15 +63,18 @@ impl ApiProvider {
             .as_ref()
             .unwrap_or(&"local".to_string())
             .clone();
-        // FIXME panics if no domains -- return Option::None instead
         let domain = ctx
             .domains
             .iter()
-            .find(|&d| &d.dns_name == &domain_name)
-            .unwrap();
-        match domain.map_to_root {
-            true => format!("{}.{}", name, domain_name),
-            false => format!("{}.{}.{}", name, project_name, domain_name),
+            .find(|&d| &d.dns_name == &domain_name);
+        match domain {
+            Some (domain) => {
+                match domain.map_to_root {
+                    true => format!("{}.{}", name, domain_name),
+                    false => format!("{}.{}.{}", name, project_name, domain_name),
+                }
+            }
+            None => format!("{}.{}.{}", name, project_name, domain_name),
         }
     }
 }

--- a/cli/src/providers/k8s.rs
+++ b/cli/src/providers/k8s.rs
@@ -62,6 +62,7 @@ impl Provider for KubernetesProvider {
 // TODO kube context name as provider option
 impl Castable for KubernetesProvider {
     fn cast(&self, ctx: Rc<Context>, _selector: Option<&str>) -> Result<Vec<Artifact>, CastError> {
+        GlooCtl::default().install_gateway();
         let registries = ctx.registries.iter().map(to_container_registry).collect();
 
         let mut service_artifacts = ctx
@@ -100,7 +101,6 @@ impl Castable for KubernetesProvider {
 
 impl Bindable for KubernetesProvider {
     fn bind(&self, ctx: Rc<Context>) -> Result<(), CastError> {
-        GlooCtl::default().install_gateway();
         ctx.services
             .iter()
             .filter(|&s| s.provider.name == self.name())


### PR DESCRIPTION
Gloo API provider panicked if no domain name was defined. Now returns a .local domain, which must be specified as the `Host` in HTTP requests. eg `curl -H "Host: mysvc.myproj.local" http://<ip>`

Also moves the Gloo Gateway installation to the `cast` step so that the CRDs will be available to Terraform.