### PR TITLE
Flag service API as "root"

### DIFF
--- a/cli/src/transpiler/context.rs
+++ b/cli/src/transpiler/context.rs
@@ -75,6 +75,7 @@ impl Context {
                     name: service_provider.name.clone(),
                     options: service_provider.options.clone(),
                 }),
+                is_root: service_manifest.api.is_root,
                 domain_name: service_manifest.api.domain_name,
                 project_name: project.name.clone(),
             });
@@ -320,6 +321,7 @@ pub struct Domain {
 pub struct Service {
     pub name: String,
     pub provider: Rc<Provider>,
+    pub is_root: Option<bool>,
     pub domain_name: Option<String>,
     pub project_name: String,
 }

--- a/cli/src/transpiler/toml.rs
+++ b/cli/src/transpiler/toml.rs
@@ -271,6 +271,7 @@ pub mod service {
     #[derive(Serialize, Deserialize, Clone, Default)]
     pub struct Api {
         pub domain_name: Option<String>,
+        pub is_root: Option<bool>,
         pub functions: Rc<Vec<Function>>,
         pub authorizers: Option<Rc<Vec<HttpAuth>>>,
     }


### PR DESCRIPTION
IFF a domain has `map_to_root` enabled, one service can specify `api.is_root=true` to deploy the service at the root domain instead of the service subdomain. 

```toml
[service]
name = "blah"

[api]
domain_name = "example.com"
is_root = true
```

Will deploy `blah` service at example.com. This is to facilitate designating one service as e.g. a web server.

If you specify is_root for more than one service it will probably break things :)