### PR TITLE
Rewrite core using Wasmtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,6 @@ dependencies = [
  "reqwest",
  "tokio",
  "toml",
- "wasmer",
  "zip",
 ]
 
@@ -324,21 +323,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "backtrace"
-version = "0.3.66"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object 0.29.0",
- "rustc-demangle",
-]
-
-[[package]]
 name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,27 +378,6 @@ name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
-
-[[package]]
-name = "bytecheck"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11cac2c12b5adc6570dad2ee1b87eff4955dac476fe12d81e5fdd352e52406f"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e576ebe98e605500b3c8041bb888e966653577172df6dd97398714eb30b9bf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "byteorder"
@@ -679,19 +642,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
-name = "corosensei"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9847f90f32a50b0dcbd68bc23ff242798b13080b97b0569f6ed96a45ce4cf2cd"
-dependencies = [
- "autocfg",
- "cfg-if",
- "libc",
- "scopeguard",
- "windows-sys 0.33.0",
-]
-
-[[package]]
 name = "cpp_demangle"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,37 +661,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.82.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38faa2a16616c8e78a18d37b4726b98bfd2de192f2fdc8a39ddf568a408a0f75"
-dependencies = [
- "cranelift-entity 0.82.3",
-]
-
-[[package]]
-name = "cranelift-bforest"
 version = "0.89.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "593b398dd0c5b1e2e3a9c3dae8584e287894ea84e361949ad506376e99196265"
 dependencies = [
- "cranelift-entity 0.89.2",
-]
-
-[[package]]
-name = "cranelift-codegen"
-version = "0.82.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26f192472a3ba23860afd07d2b0217dc628f21fcc72617aa1336d98e1671f33b"
-dependencies = [
- "cranelift-bforest 0.82.3",
- "cranelift-codegen-meta 0.82.3",
- "cranelift-codegen-shared 0.82.3",
- "cranelift-entity 0.82.3",
- "gimli",
- "log",
- "regalloc",
- "smallvec",
- "target-lexicon",
+ "cranelift-entity",
 ]
 
 [[package]]
@@ -752,10 +676,10 @@ checksum = "afc0d8faabd099ea15ab33d49d150e5572c04cfeb95d675fd41286739b754629"
 dependencies = [
  "arrayvec",
  "bumpalo",
- "cranelift-bforest 0.89.2",
- "cranelift-codegen-meta 0.89.2",
- "cranelift-codegen-shared 0.89.2",
- "cranelift-entity 0.89.2",
+ "cranelift-bforest",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-entity",
  "cranelift-isle",
  "gimli",
  "log",
@@ -766,39 +690,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.82.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f32ddb89e9b89d3d9b36a5b7d7ea3261c98235a76ac95ba46826b8ec40b1a24"
-dependencies = [
- "cranelift-codegen-shared 0.82.3",
-]
-
-[[package]]
-name = "cranelift-codegen-meta"
 version = "0.89.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac1669e42579476f001571d6ba4b825fac686282c97b88b18f8e34242066a81"
 dependencies = [
- "cranelift-codegen-shared 0.89.2",
+ "cranelift-codegen-shared",
 ]
-
-[[package]]
-name = "cranelift-codegen-shared"
-version = "0.82.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fd0d9f288cc1b42d9333b7a776b17e278fc888c28e6a0f09b5573d45a150bc"
 
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.89.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2a1b1eef9640ab72c1e7b583ac678083855a509da34b4b4378bd99954127c20"
-
-[[package]]
-name = "cranelift-entity"
-version = "0.82.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3bfe172b83167604601faf9dc60453e0d0a93415b57a9c4d1a7ae6849185cf"
 
 [[package]]
 name = "cranelift-entity"
@@ -811,23 +714,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.82.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a006e3e32d80ce0e4ba7f1f9ddf66066d052a8c884a110b91d05404d6ce26dce"
-dependencies = [
- "cranelift-codegen 0.82.3",
- "log",
- "smallvec",
- "target-lexicon",
-]
-
-[[package]]
-name = "cranelift-frontend"
 version = "0.89.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fca1474b5302348799656d43a40eacd716a3b46169405a3af812832c9edf77b4"
 dependencies = [
- "cranelift-codegen 0.89.2",
+ "cranelift-codegen",
  "log",
  "smallvec",
  "target-lexicon",
@@ -845,7 +736,7 @@ version = "0.89.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bdc6b65241a95b7d8eafbf4e114c082e49b80162a2dcd9c6bcc5989c3310c9e"
 dependencies = [
- "cranelift-codegen 0.89.2",
+ "cranelift-codegen",
  "libc",
  "target-lexicon",
 ]
@@ -856,13 +747,13 @@ version = "0.89.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb6359f606a1c80ccaa04fae9dbbb504615ec7a49b6c212b341080fff7a65dd"
 dependencies = [
- "cranelift-codegen 0.89.2",
- "cranelift-entity 0.89.2",
- "cranelift-frontend 0.89.2",
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-frontend",
  "itertools",
  "log",
  "smallvec",
- "wasmparser 0.92.0",
+ "wasmparser",
  "wasmtime-types",
 ]
 
@@ -973,40 +864,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "dialoguer"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1106,47 +963,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "enum-iterator"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
-dependencies = [
- "enum-iterator-derive",
-]
-
-[[package]]
-name = "enum-iterator-derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "enumset"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19be8061a06ab6f3a6cf21106c873578bf01bd42ad15e0311a9c76161cb1c753"
-dependencies = [
- "enumset_derive",
-]
-
-[[package]]
-name = "enumset_derive"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e7b551eba279bf0fa88b83a46330168c1560a52a94f5126f892f0b364ab3e0"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1436,15 +1252,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
@@ -1587,12 +1394,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1609,7 +1410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
- "hashbrown 0.12.3",
+ "hashbrown",
  "serde",
 ]
 
@@ -1753,16 +1554,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
-name = "libloading"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
-dependencies = [
- "cfg-if",
- "winapi",
-]
-
-[[package]]
 name = "link-cplusplus"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1800,27 +1591,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "loupe"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6a72dfa44fe15b5e76b94307eeb2ff995a8c5b283b55008940c02e0c5b634d"
-dependencies = [
- "indexmap",
- "loupe-derive",
- "rustversion",
-]
-
-[[package]]
-name = "loupe-derive"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fbfc88337168279f2e9ae06e157cfed4efd3316e14dc96ed074d4f2e6c5952"
-dependencies = [
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1863,15 +1633,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memmap2"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1906,12 +1667,6 @@ dependencies = [
  "wasi",
  "windows-sys 0.42.0",
 ]
-
-[[package]]
-name = "more-asserts"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "native-tls"
@@ -1962,24 +1717,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.28.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
-dependencies = [
- "crc32fast",
- "hashbrown 0.11.2",
- "indexmap",
- "memchr",
-]
-
-[[package]]
-name = "object"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
 dependencies = [
  "crc32fast",
- "hashbrown 0.12.3",
+ "hashbrown",
  "indexmap",
  "memchr",
 ]
@@ -2205,30 +1948,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2250,26 +1969,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2362,17 +2061,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regalloc"
-version = "0.0.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62446b1d3ebf980bdc68837700af1d77b37bc430e524bf95319c6eada2a4cc02"
-dependencies = [
- "log",
- "rustc-hash",
- "smallvec",
-]
-
-[[package]]
 name = "regalloc2"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2411,33 +2099,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
-name = "region"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e189c2369884dce920945e2ddf79b3dff49e071a167dd1817fa9c4c00d512e"
-dependencies = [
- "bitflags",
- "libc",
- "mach",
- "winapi",
-]
-
-[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "rend"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79af64b4b6362ffba04eef3a4e10829718a4896dac19daa741851c86781edf95"
-dependencies = [
- "bytecheck",
 ]
 
 [[package]]
@@ -2478,41 +2145,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rkyv"
-version = "0.7.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec2b3485b07d96ddfd3134767b8a447b45ea4eb91448d0a35180ec0ffd5ed15"
-dependencies = [
- "bytecheck",
- "hashbrown 0.12.3",
- "ptr_meta",
- "rend",
- "rkyv_derive",
- "seahash",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eaedadc88b53e36dd32d940ed21ae4d850d5916f2581526921f553a72ac34c4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -2554,12 +2190,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
-
-[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2597,12 +2227,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
 
 [[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
-
-[[package]]
 name = "security-framework"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2638,15 +2262,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -3367,243 +2982,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmer"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8d8361c9d006ea3d7797de7bd6b1492ffd0f91a22430cfda6c1658ad57bedf"
-dependencies = [
- "cfg-if",
- "indexmap",
- "js-sys",
- "loupe",
- "more-asserts",
- "target-lexicon",
- "thiserror",
- "wasm-bindgen",
- "wasmer-artifact",
- "wasmer-compiler",
- "wasmer-compiler-cranelift",
- "wasmer-derive",
- "wasmer-engine",
- "wasmer-engine-dylib",
- "wasmer-engine-universal",
- "wasmer-types",
- "wasmer-vm",
- "wat",
- "winapi",
-]
-
-[[package]]
-name = "wasmer-artifact"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aaf9428c29c1d8ad2ac0e45889ba8a568a835e33fd058964e5e500f2f7ce325"
-dependencies = [
- "enumset",
- "loupe",
- "thiserror",
- "wasmer-compiler",
- "wasmer-types",
-]
-
-[[package]]
-name = "wasmer-compiler"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67a6cd866aed456656db2cfea96c18baabbd33f676578482b85c51e1ee19d2c"
-dependencies = [
- "enumset",
- "loupe",
- "rkyv",
- "serde",
- "serde_bytes",
- "smallvec",
- "target-lexicon",
- "thiserror",
- "wasmer-types",
- "wasmparser 0.83.0",
-]
-
-[[package]]
-name = "wasmer-compiler-cranelift"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48be2f9f6495f08649e4f8b946a2cbbe119faf5a654aa1457f9504a99d23dae0"
-dependencies = [
- "cranelift-codegen 0.82.3",
- "cranelift-entity 0.82.3",
- "cranelift-frontend 0.82.3",
- "gimli",
- "loupe",
- "more-asserts",
- "rayon",
- "smallvec",
- "target-lexicon",
- "tracing",
- "wasmer-compiler",
- "wasmer-types",
-]
-
-[[package]]
-name = "wasmer-derive"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e50405cc2a2f74ff574584710a5f2c1d5c93744acce2ca0866084739284b51"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "wasmer-engine"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f98f010978c244db431b392aeab0661df7ea0822343334f8f2a920763548e45"
-dependencies = [
- "backtrace",
- "enumset",
- "lazy_static",
- "loupe",
- "memmap2",
- "more-asserts",
- "rustc-demangle",
- "serde",
- "serde_bytes",
- "target-lexicon",
- "thiserror",
- "wasmer-artifact",
- "wasmer-compiler",
- "wasmer-types",
- "wasmer-vm",
-]
-
-[[package]]
-name = "wasmer-engine-dylib"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0358af9c154724587731175553805648d9acb8f6657880d165e378672b7e53"
-dependencies = [
- "cfg-if",
- "enum-iterator",
- "enumset",
- "leb128",
- "libloading",
- "loupe",
- "object 0.28.4",
- "rkyv",
- "serde",
- "tempfile",
- "tracing",
- "wasmer-artifact",
- "wasmer-compiler",
- "wasmer-engine",
- "wasmer-object",
- "wasmer-types",
- "wasmer-vm",
- "which",
-]
-
-[[package]]
-name = "wasmer-engine-universal"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440dc3d93c9ca47865a4f4edd037ea81bf983b5796b59b3d712d844b32dbef15"
-dependencies = [
- "cfg-if",
- "enumset",
- "leb128",
- "loupe",
- "region",
- "rkyv",
- "wasmer-compiler",
- "wasmer-engine",
- "wasmer-engine-universal-artifact",
- "wasmer-types",
- "wasmer-vm",
- "winapi",
-]
-
-[[package]]
-name = "wasmer-engine-universal-artifact"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f1db3f54152657eb6e86c44b66525ff7801dad8328fe677da48dd06af9ad41"
-dependencies = [
- "enum-iterator",
- "enumset",
- "loupe",
- "rkyv",
- "thiserror",
- "wasmer-artifact",
- "wasmer-compiler",
- "wasmer-types",
-]
-
-[[package]]
-name = "wasmer-object"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d831335ff3a44ecf451303f6f891175c642488036b92ceceb24ac8623a8fa8b"
-dependencies = [
- "object 0.28.4",
- "thiserror",
- "wasmer-compiler",
- "wasmer-types",
-]
-
-[[package]]
-name = "wasmer-types"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39df01ea05dc0a9bab67e054c7cb01521e53b35a7bb90bd02eca564ed0b2667f"
-dependencies = [
- "backtrace",
- "enum-iterator",
- "indexmap",
- "loupe",
- "more-asserts",
- "rkyv",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "wasmer-vm"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d965fa61f4dc4cdb35a54daaf7ecec3563fbb94154a6c35433f879466247dd"
-dependencies = [
- "backtrace",
- "cc",
- "cfg-if",
- "corosensei",
- "enum-iterator",
- "indexmap",
- "lazy_static",
- "libc",
- "loupe",
- "mach",
- "memoffset",
- "more-asserts",
- "region",
- "rkyv",
- "scopeguard",
- "serde",
- "thiserror",
- "wasmer-artifact",
- "wasmer-types",
- "winapi",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.83.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
-
-[[package]]
 name = "wasmparser"
 version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3625,14 +3003,14 @@ dependencies = [
  "indexmap",
  "libc",
  "log",
- "object 0.29.0",
+ "object",
  "once_cell",
  "paste 1.0.9",
  "psm",
  "rayon",
  "serde",
  "target-lexicon",
- "wasmparser 0.92.0",
+ "wasmparser",
  "wasmtime-cache",
  "wasmtime-cranelift",
  "wasmtime-environ",
@@ -3679,17 +3057,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "017c3605ccce867b3ba7f71d95e5652acc22b9dc2971ad6a6f9df4a8d7af2648"
 dependencies = [
  "anyhow",
- "cranelift-codegen 0.89.2",
- "cranelift-entity 0.89.2",
- "cranelift-frontend 0.89.2",
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-frontend",
  "cranelift-native",
  "cranelift-wasm",
  "gimli",
  "log",
- "object 0.29.0",
+ "object",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.92.0",
+ "wasmparser",
  "wasmtime-environ",
 ]
 
@@ -3700,15 +3078,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aec5c1f81aab9bb35997113c171b6bb9093afc90e3757c55e0c08dc9ac612e4"
 dependencies = [
  "anyhow",
- "cranelift-entity 0.89.2",
+ "cranelift-entity",
  "gimli",
  "indexmap",
  "log",
- "object 0.29.0",
+ "object",
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.92.0",
+ "wasmparser",
  "wasmtime-types",
 ]
 
@@ -3739,7 +3117,7 @@ dependencies = [
  "gimli",
  "ittapi",
  "log",
- "object 0.29.0",
+ "object",
  "rustc-demangle",
  "rustix 0.35.13",
  "serde",
@@ -3757,7 +3135,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2f8f15a81292eec468c79a4f887a37a3d02eb0c610f34ddbec607d3e9022f18"
 dependencies = [
- "object 0.29.0",
+ "object",
  "once_cell",
  "rustix 0.35.13",
 ]
@@ -3794,10 +3172,10 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dc3dd9521815984b35d6362f79e6b9c72475027cd1c71c44eb8df8fbf33a9fb"
 dependencies = [
- "cranelift-entity 0.89.2",
+ "cranelift-entity",
  "serde",
  "thiserror",
- "wasmparser 0.92.0",
+ "wasmparser",
 ]
 
 [[package]]
@@ -3851,17 +3229,6 @@ checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "which"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
-dependencies = [
- "either",
- "libc",
- "once_cell",
 ]
 
 [[package]]
@@ -3939,19 +3306,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43dbb096663629518eb1dfa72d80243ca5a6aca764cae62a2df70af760a9be75"
-dependencies = [
- "windows_aarch64_msvc 0.33.0",
- "windows_i686_gnu 0.33.0",
- "windows_i686_msvc 0.33.0",
- "windows_x86_64_gnu 0.33.0",
- "windows_x86_64_msvc 0.33.0",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
@@ -3986,12 +3340,6 @@ checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd761fd3eb9ab8cc1ed81e56e567f02dd82c4c837e48ac3b2181b9ffc5060807"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
@@ -4001,12 +3349,6 @@ name = "windows_aarch64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab0cf703a96bab2dc0c02c0fa748491294bf9b7feb27e1f4f96340f208ada0e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4022,12 +3364,6 @@ checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfdbe89cc9ad7ce618ba34abc34bbb6c36d99e96cae2245b7943cd75ee773d0"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
@@ -4037,12 +3373,6 @@ name = "windows_i686_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4dd9b0c0e9ece7bb22e84d70d01b71c6d6248b81a3c60d11869451b4cb24784"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4061,12 +3391,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1e4aa646495048ec7f3ffddc411e1d829c026a2ec62b39da15c1055e406eaa"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ name = "assemblylift-awslambda-guest"
 version = "0.4.0-alpha.0"
 dependencies = [
  "assemblylift-core-guest",
- "assemblylift-core-io-guest 0.4.0-alpha.0",
+ "assemblylift-core-io-guest 0.4.0-alpha.10",
  "direct-executor",
  "serde",
  "serde_json",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "assemblylift-core-io-guest"
-version = "0.4.0-alpha.0"
+version = "0.4.0-alpha.10"
 dependencies = [
  "assemblylift-core-io-common 0.3.0",
  "futures",
@@ -262,7 +262,7 @@ version = "0.4.0-alpha.0"
 
 [[package]]
 name = "assemblylift-hyper-runtime"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.10"
 dependencies = [
  "anyhow",
  "assemblylift-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cipher",
  "cpufeatures",
  "opaque-debug",
@@ -50,6 +50,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec8ad6edb4840b78c5c3d88de606b22252d552b55f3a4699fbb10fc070ec3049"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,6 +78,12 @@ name = "anyhow"
 version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9a8f622bcf6ff3df478e9deba3e03e4e04b300f8e6a139e192c05fa3490afc7"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "asml-iomod-registry-common"
@@ -145,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "assemblylift-core"
-version = "0.4.0-alpha.3"
+version = "0.4.0-alpha.10"
 dependencies = [
  "anyhow",
  "assemblylift-core-io-common 0.3.0",
@@ -153,8 +165,8 @@ dependencies = [
  "crossbeam-channel",
  "once_cell",
  "tokio",
- "wasmer",
- "wasmer-wasi",
+ "wasmtime",
+ "wasmtime-wasi",
  "z85",
 ]
 
@@ -234,7 +246,7 @@ dependencies = [
  "lazy_static",
  "once_cell",
  "paste 1.0.9",
- "rustc_version 0.4.0",
+ "rustc_version",
  "serde",
  "tokio",
  "tokio-util 0.6.10",
@@ -269,7 +281,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "wasmer",
  "z85",
  "zip",
 ]
@@ -289,12 +300,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -313,18 +335,12 @@ checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "miniz_oxide",
  "object 0.29.0",
  "rustc-demangle",
 ]
-
-[[package]]
-name = "base-x"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
 name = "base64"
@@ -345,10 +361,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a32fd6af2b5827bce66c29053ba0e7c42b9dcab01835835058558c10851a46b"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block-buffer"
@@ -426,6 +460,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "cap-fs-ext"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b0e103ce36d217d568903ad27b14ec2238ecb5d65bad2e756a8f3c0d651506e"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes 0.7.5",
+ "windows-sys 0.36.1",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af3f336aa91cce16033ed3c94ac91d98956c49b420e6d6cd0dd7d0e386a57085"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 0.7.5",
+ "ipnet",
+ "maybe-owned",
+ "rustix 0.35.13",
+ "winapi-util",
+ "windows-sys 0.36.1",
+ "winx",
+]
+
+[[package]]
+name = "cap-rand"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d14b9606aa9550d34651bc481443203bc014237bdb992d201d2afa62d2ec6dea"
+dependencies = [
+ "ambient-authority",
+ "rand",
+]
+
+[[package]]
+name = "cap-std"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9d6e70b626eceac9d6fc790fe2d72cc3f2f7bc3c35f467690c54a526b0f56db"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes 0.7.5",
+ "ipnet",
+ "rustix 0.35.13",
+]
+
+[[package]]
+name = "cap-time-ext"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a0524f7c4cff2ea547ae2b652bf7a348fd3e48f76556dc928d8b45ab2f1d50"
+dependencies = [
+ "cap-primitives",
+ "once_cell",
+ "rustix 0.35.13",
+ "winx",
+]
+
+[[package]]
 name = "capnp"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,12 +568,6 @@ checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 dependencies = [
  "jobserver",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -558,12 +651,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_fn"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
-
-[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,10 +679,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9847f90f32a50b0dcbd68bc23ff242798b13080b97b0569f6ed96a45ce4cf2cd"
 dependencies = [
  "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "scopeguard",
  "windows-sys 0.33.0",
+]
+
+[[package]]
+name = "cpp_demangle"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeaa953eaad386a53111e47172c2fedba671e5684c8dd601a5f474f4f118710f"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -613,7 +709,16 @@ version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38faa2a16616c8e78a18d37b4726b98bfd2de192f2fdc8a39ddf568a408a0f75"
 dependencies = [
- "cranelift-entity",
+ "cranelift-entity 0.82.3",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.89.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "593b398dd0c5b1e2e3a9c3dae8584e287894ea84e361949ad506376e99196265"
+dependencies = [
+ "cranelift-entity 0.89.2",
 ]
 
 [[package]]
@@ -622,13 +727,33 @@ version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26f192472a3ba23860afd07d2b0217dc628f21fcc72617aa1336d98e1671f33b"
 dependencies = [
- "cranelift-bforest",
- "cranelift-codegen-meta",
- "cranelift-codegen-shared",
- "cranelift-entity",
+ "cranelift-bforest 0.82.3",
+ "cranelift-codegen-meta 0.82.3",
+ "cranelift-codegen-shared 0.82.3",
+ "cranelift-entity 0.82.3",
  "gimli",
  "log",
  "regalloc",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.89.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc0d8faabd099ea15ab33d49d150e5572c04cfeb95d675fd41286739b754629"
+dependencies = [
+ "arrayvec",
+ "bumpalo",
+ "cranelift-bforest 0.89.2",
+ "cranelift-codegen-meta 0.89.2",
+ "cranelift-codegen-shared 0.89.2",
+ "cranelift-entity 0.89.2",
+ "cranelift-isle",
+ "gimli",
+ "log",
+ "regalloc2",
  "smallvec",
  "target-lexicon",
 ]
@@ -639,7 +764,16 @@ version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f32ddb89e9b89d3d9b36a5b7d7ea3261c98235a76ac95ba46826b8ec40b1a24"
 dependencies = [
- "cranelift-codegen-shared",
+ "cranelift-codegen-shared 0.82.3",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.89.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac1669e42579476f001571d6ba4b825fac686282c97b88b18f8e34242066a81"
+dependencies = [
+ "cranelift-codegen-shared 0.89.2",
 ]
 
 [[package]]
@@ -649,10 +783,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01fd0d9f288cc1b42d9333b7a776b17e278fc888c28e6a0f09b5573d45a150bc"
 
 [[package]]
+name = "cranelift-codegen-shared"
+version = "0.89.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2a1b1eef9640ab72c1e7b583ac678083855a509da34b4b4378bd99954127c20"
+
+[[package]]
 name = "cranelift-entity"
 version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e3bfe172b83167604601faf9dc60453e0d0a93415b57a9c4d1a7ae6849185cf"
+
+[[package]]
+name = "cranelift-entity"
+version = "0.89.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea4e17c3791fd8134640b26242a9ddbd7c67db78f0bad98cb778bf563ef81a0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cranelift-frontend"
@@ -660,10 +809,55 @@ version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a006e3e32d80ce0e4ba7f1f9ddf66066d052a8c884a110b91d05404d6ce26dce"
 dependencies = [
- "cranelift-codegen",
+ "cranelift-codegen 0.82.3",
  "log",
  "smallvec",
  "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.89.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca1474b5302348799656d43a40eacd716a3b46169405a3af812832c9edf77b4"
+dependencies = [
+ "cranelift-codegen 0.89.2",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.89.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77aa537f020ea43483100153278e7215d41695bdcef9eea6642d122675f64249"
+
+[[package]]
+name = "cranelift-native"
+version = "0.89.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bdc6b65241a95b7d8eafbf4e114c082e49b80162a2dcd9c6bcc5989c3310c9e"
+dependencies = [
+ "cranelift-codegen 0.89.2",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-wasm"
+version = "0.89.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb6359f606a1c80ccaa04fae9dbbb504615ec7a49b6c212b341080fff7a65dd"
+dependencies = [
+ "cranelift-codegen 0.89.2",
+ "cranelift-entity 0.89.2",
+ "cranelift-frontend 0.89.2",
+ "itertools",
+ "log",
+ "smallvec",
+ "wasmparser 0.92.0",
+ "wasmtime-types",
 ]
 
 [[package]]
@@ -672,7 +866,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -681,7 +875,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -691,7 +885,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -703,7 +897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
 dependencies = [
  "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
  "memoffset",
  "once_cell",
@@ -716,7 +910,7 @@ version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
 ]
 
@@ -777,11 +971,20 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.3",
  "crypto-common",
  "subtle",
 ]
@@ -796,10 +999,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "discard"
-version = "1.0.4"
+name = "directories-next"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
 
 [[package]]
 name = "dynasm"
@@ -845,7 +1083,7 @@ version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -890,6 +1128,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -905,12 +1177,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "file-per-thread-logger"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e16290574b39ee41c71aeb90ae960c504ebaf1e2a1c87bd52aa56ed6e1a02f"
+dependencies = [
+ "env_logger",
+ "log",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e94a7bbaa59354bc20dd75b67f23e2797b4490e9d6928203fb105c79e448c86c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "windows-sys 0.36.1",
@@ -955,6 +1237,17 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-set-times"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a267b6a9304912e018610d53fe07115d8b530b160e85db4d2d3a59f3ddde1aec"
+dependencies = [
+ "io-lifetimes 0.7.5",
+ "rustix 0.35.13",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -1047,12 +1340,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "generational-arena"
-version = "0.2.8"
+name = "fxhash"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d3b771574f62d0548cee0ad9057857e9fc25d7a3335f140c84f6acd0bf601"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
- "cfg-if 0.1.10",
+ "byteorder",
 ]
 
 [[package]]
@@ -1071,7 +1364,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi",
 ]
@@ -1139,10 +1432,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -1153,7 +1461,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -1189,6 +1497,12 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -1275,7 +1589,37 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
+]
+
+[[package]]
+name = "io-extras"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5d8c2ab5becd8720e30fd25f8fa5500d8dc3fceadd8378f05859bd7b46fc49"
+dependencies = [
+ "io-lifetimes 0.7.5",
+ "windows-sys 0.36.1",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7d367024b3f3414d8e01f437f704f41a9f64ab36f9067fa73e526ad4c763c87"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1283,6 +1627,18 @@ name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+
+[[package]]
+name = "is-terminal"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d508111813f9af3afd2f92758f77e4ed2cc9371b642112c6a48d22eb73105c5"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes 0.7.5",
+ "rustix 0.35.13",
+ "windows-sys 0.36.1",
+]
 
 [[package]]
 name = "itertools"
@@ -1298,6 +1654,26 @@ name = "itoa"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+
+[[package]]
+name = "ittapi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "663fe0550070071ff59e981864a9cd3ee1c869ed0a088140d9ac4dc05ea6b1a1"
+dependencies = [
+ "anyhow",
+ "ittapi-sys",
+ "log",
+]
+
+[[package]]
+name = "ittapi-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e21911b7183f38c71d75ab478a527f314e28db51027037ece2e5511ed9410703"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "jobserver"
@@ -1342,9 +1718,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "libloading"
@@ -1352,9 +1728,21 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "winapi",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb68f22743a3fb35785f1e7f844ca5a3de2dde5bd0c0ef5b372065814699b121"
 
 [[package]]
 name = "lock_api"
@@ -1372,7 +1760,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1421,10 +1809,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memfd"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b20a59d985586e4a5aef64564ac77299f8586d8be6cf9106a5a40207e8908efb"
+dependencies = [
+ "rustix 0.36.1",
+]
 
 [[package]]
 name = "memmap2"
@@ -1520,7 +1923,7 @@ version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -1551,6 +1954,9 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
 dependencies = [
+ "crc32fast",
+ "hashbrown 0.12.3",
+ "indexmap",
  "memchr",
 ]
 
@@ -1573,7 +1979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
 dependencies = [
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
@@ -1633,7 +2039,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -1642,9 +2048,9 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.3.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d791538a6dcc1e7cb7fe6f6b58aca40e7f79403c45b2bc274008b5e647af1d8"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
 dependencies = [
  "base64ct",
  "rand_core",
@@ -1690,14 +2096,14 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest",
+ "digest 0.10.3",
  "hmac",
  "password-hash",
- "sha2",
+ "sha2 0.10.5",
 ]
 
 [[package]]
@@ -1769,6 +2175,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1808,6 +2220,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1843,10 +2264,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "rayon"
@@ -1882,6 +2327,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
 name = "regalloc"
 version = "0.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,6 +2345,18 @@ checksum = "62446b1d3ebf980bdc68837700af1d77b37bc430e524bf95319c6eada2a4cc02"
 dependencies = [
  "log",
  "rustc-hash",
+ "smallvec",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91b2eab54204ea0117fe9a060537e0b07a4e72f7c7d182361ecc346cab2240e5"
+dependencies = [
+ "fxhash",
+ "log",
+ "slice-group-by",
  "smallvec",
 ]
 
@@ -2024,20 +2492,41 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.13",
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.35.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727a1a6d65f786ec22df8a81ca3121107f235970dc1705ed681d3e6e8b9cd5f9"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes 0.7.5",
+ "itoa",
+ "libc",
+ "linux-raw-sys 0.0.46",
+ "once_cell",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812a2ec2043c4d6bc6482f5be2ab8244613cac2493d128d36c0759e52a626ab3"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes 1.0.1",
+ "libc",
+ "linux-raw-sys 0.1.2",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2108,24 +2597,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -2186,18 +2660,9 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
- "digest",
-]
-
-[[package]]
-name = "sha1"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
-dependencies = [
- "sha1_smol",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -2206,16 +2671,23 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "006769ba83e921b3085caa8334186b00cf92b4cb1a6cf4632fbccc8eff5c7549"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.3",
 ]
 
 [[package]]
-name = "sha1_smol"
-version = "1.0.0"
+name = "sha2"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
 
 [[package]]
 name = "sha2"
@@ -2223,9 +2695,9 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9db03534dff993187064c4e0c05a5708d2a9728ace9a8959b77bedf415dac5"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -2235,6 +2707,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shellexpand"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ccc8076840c4da029af4f87e4e8daeb0fca6b87bbb02e10cb60b791450e11e4"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]
@@ -2254,6 +2735,12 @@ checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "slice-group-by"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
 
 [[package]]
 name = "smallvec"
@@ -2278,68 +2765,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
-name = "standback"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "std_prelude"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8207e78455ffdf55661170876f88daf85356e4edd54e0a3dbc79586ca1e50cbe"
-
-[[package]]
-name = "stdweb"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
-dependencies = [
- "discard",
- "rustc_version 0.2.3",
- "stdweb-derive",
- "stdweb-internal-macros",
- "stdweb-internal-runtime",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "stdweb-derive"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-macros"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
-dependencies = [
- "base-x",
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "serde_json",
- "sha1 0.6.1",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-runtime"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "stfu8"
@@ -2381,6 +2810,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-interface"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92adbaf536f5aff6986e1e62ba36cee72b1718c5153eee08b9e728ddde3f6029"
+dependencies = [
+ "atty",
+ "bitflags",
+ "cap-fs-ext",
+ "cap-std",
+ "io-lifetimes 0.7.5",
+ "rustix 0.35.13",
+ "windows-sys 0.36.1",
+ "winx",
+]
+
+[[package]]
 name = "tar"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2403,7 +2848,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fastrand",
  "libc",
  "redox_syscall",
@@ -2476,21 +2921,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
-dependencies = [
- "const_fn",
- "libc",
- "standback",
- "stdweb",
- "time-macros 0.1.1",
- "version_check",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
@@ -2498,17 +2928,7 @@ dependencies = [
  "itoa",
  "libc",
  "num_threads",
- "time-macros 0.2.4",
-]
-
-[[package]]
-name = "time-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
-dependencies = [
- "proc-macro-hack",
- "time-macros-impl",
+ "time-macros",
 ]
 
 [[package]]
@@ -2516,19 +2936,6 @@ name = "time-macros"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
-
-[[package]]
-name = "time-macros-impl"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "standback",
- "syn",
-]
 
 [[package]]
 name = "tinyvec"
@@ -2637,7 +3044,7 @@ version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -2816,12 +3223,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi-cap-std-sync"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4b4953999c746173c263b81e9e5e3e335ff47face7187ba2a5ecc91c716e6f3"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cap-fs-ext",
+ "cap-rand",
+ "cap-std",
+ "cap-time-ext",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 0.7.5",
+ "is-terminal",
+ "once_cell",
+ "rustix 0.35.13",
+ "system-interface",
+ "tracing",
+ "wasi-common",
+ "windows-sys 0.36.1",
+]
+
+[[package]]
+name = "wasi-common"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d47faf4f76ebfdeb1f3346a949c6fbf2f2471afc68280b00c76d6c02221d80ad"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "cap-rand",
+ "cap-std",
+ "io-extras",
+ "rustix 0.35.13",
+ "thiserror",
+ "tracing",
+ "wiggle",
+ "windows-sys 0.36.1",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
@@ -2846,7 +3295,7 @@ version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -2883,9 +3332,9 @@ checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.16.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d443c5a7daae71697d97ec12ad70b4fe8766d3a0f4db16158ac8b781365892f7"
+checksum = "9424cdab516a16d4ea03c8f4a01b14e7b2d04a129dcc2bcdde5bcc5f68f06c41"
 dependencies = [
  "leb128",
 ]
@@ -2896,7 +3345,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea8d8361c9d006ea3d7797de7bd6b1492ffd0f91a22430cfda6c1658ad57bedf"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "indexmap",
  "js-sys",
  "loupe",
@@ -2945,7 +3394,7 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "wasmer-types",
- "wasmparser",
+ "wasmparser 0.83.0",
 ]
 
 [[package]]
@@ -2954,9 +3403,9 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48be2f9f6495f08649e4f8b946a2cbbe119faf5a654aa1457f9504a99d23dae0"
 dependencies = [
- "cranelift-codegen",
- "cranelift-entity",
- "cranelift-frontend",
+ "cranelift-codegen 0.82.3",
+ "cranelift-entity 0.82.3",
+ "cranelift-frontend 0.82.3",
  "gimli",
  "loupe",
  "more-asserts",
@@ -3028,7 +3477,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0358af9c154724587731175553805648d9acb8f6657880d165e378672b7e53"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "enum-iterator",
  "enumset",
  "leb128",
@@ -3054,7 +3503,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "440dc3d93c9ca47865a4f4edd037ea81bf983b5796b59b3d712d844b32dbef15"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "enumset",
  "leb128",
  "loupe",
@@ -3113,17 +3562,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmer-vfs"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9302eae3edc53cb540c2d681e7f16d8274918c1ce207591f04fed351649e97c0"
-dependencies = [
- "libc",
- "thiserror",
- "tracing",
-]
-
-[[package]]
 name = "wasmer-vm"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3131,7 +3569,7 @@ checksum = "30d965fa61f4dc4cdb35a54daaf7ecec3563fbb94154a6c35433f879466247dd"
 dependencies = [
  "backtrace",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "corosensei",
  "enum-iterator",
  "indexmap",
@@ -3152,46 +3590,235 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmer-wasi"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadbe31e3c1b6f3e398ad172b169152ae1a743ae6efd5f9ffb34019983319d99"
-dependencies = [
- "cfg-if 1.0.0",
- "generational-arena",
- "getrandom",
- "libc",
- "thiserror",
- "tracing",
- "wasm-bindgen",
- "wasmer",
- "wasmer-vfs",
- "wasmer-wasi-types",
- "winapi",
-]
-
-[[package]]
-name = "wasmer-wasi-types"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22dc83aadbdf97388de3211cb6f105374f245a3cf2a5c65a16776e7a087a8468"
-dependencies = [
- "byteorder",
- "time 0.2.27",
- "wasmer-types",
-]
-
-[[package]]
 name = "wasmparser"
 version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
 
 [[package]]
-name = "wast"
-version = "46.0.0"
+name = "wasmparser"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0ab19660e3ea6891bba69167b9be40fad00fb1fe3dd39c5eebcee15607131b"
+checksum = "7da34cec2a8c23db906cdf8b26e988d7a7f0d549eb5d51299129647af61a1b37"
+dependencies = [
+ "indexmap",
+]
+
+[[package]]
+name = "wasmtime"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743d37c265fa134a76de653c7e66be22590eaccd03da13cee99f3ac7a59cb826"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bincode",
+ "cfg-if",
+ "indexmap",
+ "libc",
+ "log",
+ "object 0.29.0",
+ "once_cell",
+ "paste 1.0.9",
+ "psm",
+ "rayon",
+ "serde",
+ "target-lexicon",
+ "wasmparser 0.92.0",
+ "wasmtime-cache",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
+ "wasmtime-fiber",
+ "wasmtime-jit",
+ "wasmtime-runtime",
+ "wat",
+ "windows-sys 0.36.1",
+]
+
+[[package]]
+name = "wasmtime-asm-macros"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de327cf46d5218315957138131ed904621e6f99018aa2da508c0dcf0c65f1bf2"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-cache"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42bd53d27df1076100519b680b45d8209aed62b4bbaf0913732810cb216f7b2b"
+dependencies = [
+ "anyhow",
+ "base64 0.13.0",
+ "bincode",
+ "directories-next",
+ "file-per-thread-logger",
+ "log",
+ "rustix 0.35.13",
+ "serde",
+ "sha2 0.9.9",
+ "toml",
+ "windows-sys 0.36.1",
+ "zstd",
+]
+
+[[package]]
+name = "wasmtime-cranelift"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "017c3605ccce867b3ba7f71d95e5652acc22b9dc2971ad6a6f9df4a8d7af2648"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen 0.89.2",
+ "cranelift-entity 0.89.2",
+ "cranelift-frontend 0.89.2",
+ "cranelift-native",
+ "cranelift-wasm",
+ "gimli",
+ "log",
+ "object 0.29.0",
+ "target-lexicon",
+ "thiserror",
+ "wasmparser 0.92.0",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aec5c1f81aab9bb35997113c171b6bb9093afc90e3757c55e0c08dc9ac612e4"
+dependencies = [
+ "anyhow",
+ "cranelift-entity 0.89.2",
+ "gimli",
+ "indexmap",
+ "log",
+ "object 0.29.0",
+ "serde",
+ "target-lexicon",
+ "thiserror",
+ "wasmparser 0.92.0",
+ "wasmtime-types",
+]
+
+[[package]]
+name = "wasmtime-fiber"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1075aa43857086ef89afbe87602fe2dae98ad212582e722b6d3d2676bb5ee141"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "rustix 0.35.13",
+ "wasmtime-asm-macros",
+ "windows-sys 0.36.1",
+]
+
+[[package]]
+name = "wasmtime-jit"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c683893dbba3986aa71582a5332b87157fb95d34098de2e5f077c7f078726d"
+dependencies = [
+ "addr2line",
+ "anyhow",
+ "bincode",
+ "cfg-if",
+ "cpp_demangle",
+ "gimli",
+ "ittapi",
+ "log",
+ "object 0.29.0",
+ "rustc-demangle",
+ "rustix 0.35.13",
+ "serde",
+ "target-lexicon",
+ "thiserror",
+ "wasmtime-environ",
+ "wasmtime-jit-debug",
+ "wasmtime-runtime",
+ "windows-sys 0.36.1",
+]
+
+[[package]]
+name = "wasmtime-jit-debug"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2f8f15a81292eec468c79a4f887a37a3d02eb0c610f34ddbec607d3e9022f18"
+dependencies = [
+ "object 0.29.0",
+ "once_cell",
+ "rustix 0.35.13",
+]
+
+[[package]]
+name = "wasmtime-runtime"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09af6238c962e8220424c815a7b1a9a6d0ba0694f0ab0ae12a6cda1923935a0d"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if",
+ "indexmap",
+ "libc",
+ "log",
+ "mach",
+ "memfd",
+ "memoffset",
+ "paste 1.0.9",
+ "rand",
+ "rustix 0.35.13",
+ "thiserror",
+ "wasmtime-asm-macros",
+ "wasmtime-environ",
+ "wasmtime-fiber",
+ "wasmtime-jit-debug",
+ "windows-sys 0.36.1",
+]
+
+[[package]]
+name = "wasmtime-types"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dc3dd9521815984b35d6362f79e6b9c72475027cd1c71c44eb8df8fbf33a9fb"
+dependencies = [
+ "cranelift-entity 0.89.2",
+ "serde",
+ "thiserror",
+ "wasmparser 0.92.0",
+]
+
+[[package]]
+name = "wasmtime-wasi"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3bba5cc0a940cef3fbbfa7291c7e5fe0f7ec6fb2efa7bd1504032ed6202a1c0"
+dependencies = [
+ "anyhow",
+ "wasi-cap-std-sync",
+ "wasi-common",
+ "wasmtime",
+ "wiggle",
+]
+
+[[package]]
+name = "wast"
+version = "35.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wast"
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ef81fcd60d244cafffeafac3d17615fdb2fddda6aca18f34a8ae233353587c"
 dependencies = [
  "leb128",
  "memchr",
@@ -3201,11 +3828,11 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.48"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f775282def4d5bffd94d60d6ecd57bfe6faa46171cdbf8d32bd5458842b1e3e"
+checksum = "4c347c4460ffb311e95aafccd8c29e4888f241b9e4b3bb0e0ccbd998de2c8c0d"
 dependencies = [
- "wast",
+ "wast 49.0.0",
 ]
 
 [[package]]
@@ -3227,6 +3854,48 @@ dependencies = [
  "either",
  "libc",
  "once_cell",
+]
+
+[[package]]
+name = "wiggle"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "211ef4d238fd83bbe6f1bc57f3e2e20dc8b1f999188be252e7a535b696c6f84f"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bitflags",
+ "thiserror",
+ "tracing",
+ "wasmtime",
+ "wiggle-macro",
+]
+
+[[package]]
+name = "wiggle-generate"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63feec26b2fc3708c7a63316949ca75dd96988f03a17e4cb8d533dc62587ada4"
+dependencies = [
+ "anyhow",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "shellexpand",
+ "syn",
+ "witx",
+]
+
+[[package]]
+name = "wiggle-macro"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494dc2646618c2b7fb0ec5e1d27dbac5ca31194c00a64698a4b5b35a83d80c21"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wiggle-generate",
 ]
 
 [[package]]
@@ -3287,6 +3956,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3297,6 +3987,12 @@ name = "windows_aarch64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3311,6 +4007,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3321,6 +4023,12 @@ name = "windows_i686_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3335,6 +4043,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3347,12 +4067,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+
+[[package]]
 name = "winreg"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "winx"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7b01e010390eb263a4518c8cebf86cb67469d1511c00b749a47b64c39e8054d"
+dependencies = [
+ "bitflags",
+ "io-lifetimes 0.7.5",
+ "windows-sys 0.36.1",
+]
+
+[[package]]
+name = "witx"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e366f27a5cabcddb2706a78296a40b8fcc451e1a6aba2fc1d94b4a01bdaaef4b"
+dependencies = [
+ "anyhow",
+ "log",
+ "thiserror",
+ "wast 35.0.2",
 ]
 
 [[package]]
@@ -3378,9 +4127,9 @@ checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
 
 [[package]]
 name = "zip"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf225bcf73bb52cbb496e70475c7bd7a3f769df699c0020f6c7bd9a96dcf0b8d"
+checksum = "537ce7411d25e54e8ae21a7ce0b15840e7bfcff15b51d697ec3266cc76bdf080"
 dependencies = [
  "aes",
  "byteorder",
@@ -3391,25 +4140,25 @@ dependencies = [
  "flate2",
  "hmac",
  "pbkdf2",
- "sha1 0.10.4",
- "time 0.3.14",
+ "sha1",
+ "time",
  "zstd",
 ]
 
 [[package]]
 name = "zstd"
-version = "0.10.2+zstd.1.5.2"
+version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4a6bd64f22b5e3e94b4e238669ff9f10815c27a5180108b849d24174a83847"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "4.1.6+zstd.1.5.2"
+version = "5.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b61c51bb270702d6167b8ce67340d2754b088d0c091b06e593aa772c3ee9bb"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -3417,9 +4166,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.6.3+zstd.1.5.2"
+version = "2.0.1+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
+checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.66"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "arrayvec"
@@ -130,7 +130,7 @@ dependencies = [
  "assemblylift-core",
  "assemblylift-core-iomod",
  "base64 0.13.1",
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "clap 2.34.0",
  "dialoguer",
  "flate2",
@@ -241,7 +241,7 @@ dependencies = [
  "futures-util",
  "lazy_static",
  "once_cell",
- "paste 1.0.9",
+ "paste 1.0.11",
  "rustc_version",
  "serde",
  "tokio",
@@ -297,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.58"
+version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
+checksum = "677d1d8ab452a3936018a687b20e6f7cf5363d713b732b8884001317b0e48aa3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -394,9 +394,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "bzip2"
@@ -486,9 +486,9 @@ dependencies = [
 
 [[package]]
 name = "capnp"
-version = "0.14.10"
+version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddf2d33bdc66ac282c34d34ecc9f8d8f1d82d1540994c5f8ed1c36dd0f95aaf3"
+checksum = "2dca085c2c7d9d65ad749d450b19b551efaa8e3476a439bdca07aca8533097f3"
 
 [[package]]
 name = "capnp-futures"
@@ -522,9 +522,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 dependencies = [
  "jobserver",
 ]
@@ -790,22 +790,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.11"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
+ "memoffset 0.7.1",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if",
 ]
@@ -822,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.81"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97abf9f0eca9e52b7f81b945524e76710e6cb2366aead23b7d4fbf72e281f888"
+checksum = "5add3fc1717409d029b20c5b6903fc0c0b02fa6741d820054f4a2efa5e5816fd"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -834,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.81"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc32cc5fea1d894b77d269ddb9f192110069a8a9c1f1d441195fba90553dea3"
+checksum = "b4c87959ba14bc6fbc61df77c3fcfe180fc32b93538c4f1031dd802ccb5f2ff0"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -849,15 +849,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.81"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca220e4794c934dc6b1207c3b42856ad4c302f2df1712e9f8d2eec5afaacf1f"
+checksum = "69a3e162fde4e594ed2b07d0f83c6c67b745e7f28ce58c6df5e6b6bef99dfb59"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.81"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b846f081361125bfc8dc9d3940c84e1fd83ba54bbca7b17cd29483c828be0704"
+checksum = "3e7e2adeb6a0d4a282e581096b06e1791532b7d576dcde5ccd9382acf55db8e6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1027,9 +1027,9 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9663d381d07ae25dc88dbdf27df458faa83a9b25336bcac83d5e452b5fc9d3"
+checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1039,9 +1039,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1224,7 +1224,7 @@ version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
 dependencies = [
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1299,7 +1299,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "fnv",
  "itoa",
 ]
@@ -1310,7 +1310,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "http",
  "pin-project-lite",
 ]
@@ -1339,7 +1339,7 @@ version = "0.14.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
 dependencies = [
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1363,7 +1363,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "hyper",
  "native-tls",
  "tokio",
@@ -1446,9 +1446,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7d367024b3f3414d8e01f437f704f41a9f64ab36f9067fa73e526ad4c763c87"
+checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
 dependencies = [
  "libc",
  "windows-sys 0.42.0",
@@ -1456,9 +1456,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.5.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
+checksum = "11b0d96e660696543b251e58030cf9787df56da39dab19ad60eae7353040917e"
 
 [[package]]
 name = "is-terminal"
@@ -1483,9 +1483,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "ittapi"
@@ -1550,15 +1550,15 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
 dependencies = [
  "cc",
 ]
@@ -1571,9 +1571,9 @@ checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb68f22743a3fb35785f1e7f844ca5a3de2dde5bd0c0ef5b372065814699b121"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
@@ -1630,7 +1630,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b20a59d985586e4a5aef64564ac77299f8586d8be6cf9106a5a40207e8908efb"
 dependencies = [
- "rustix 0.36.1",
+ "rustix 0.36.5",
 ]
 
 [[package]]
@@ -1643,6 +1643,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1650,9 +1659,9 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.4"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
 ]
@@ -1708,11 +1717,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -1742,9 +1751,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.42"
+version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
+checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1774,9 +1783,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.77"
+version = "0.9.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03b84c3b2d099b81f0953422b4d4ad58761589d0229b5506356afca05a3670a"
+checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
 dependencies = [
  "autocfg",
  "cc",
@@ -1787,9 +1796,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.0"
+version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "parking_lot"
@@ -1803,9 +1812,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1837,9 +1846,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
+checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
 name = "paste-impl"
@@ -1882,9 +1891,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.4.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a528564cc62c19a7acac4d81e01f39e53e25e17b934878f4c6d25cc2836e62f8"
+checksum = "0f6e86fb9e7026527a0d46bc308b841d73170ef8f443e1807f6ef88526a816d4"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1892,9 +1901,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.4.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fd9bc6500181952d34bd0b2b0163a54d794227b498be0b7afa7698d0a7b18f"
+checksum = "96504449aa860c8dcde14f9fba5c58dc6658688ca1fe363589d6327b8662c603"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1902,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.4.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2610d5ac5156217b4ff8e46ddcef7cdf44b273da2ac5bca2ecbfa86a330e7c4"
+checksum = "798e0220d1111ae63d66cb66a5dcb3fc2d986d520b98e49e1852bfdb11d7c5e7"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1915,9 +1924,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.4.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824749bf7e21dd66b36fbe26b3f45c713879cccd4a009a917ab8e045ca8246fe"
+checksum = "984298b75898e30a843e278a9f2452c31e349a073a0ce6fd950a12a74464e065"
 dependencies = [
  "once_cell",
  "pest",
@@ -1950,15 +1959,15 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.19"
+version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
@@ -1980,9 +1989,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -2019,21 +2028,19 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.3"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
 dependencies = [
- "autocfg",
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.3"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -2115,7 +2122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
  "base64 0.13.1",
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -2178,23 +2185,23 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.1"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812a2ec2043c4d6bc6482f5be2ab8244613cac2493d128d36c0759e52a626ab3"
+checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes 1.0.1",
+ "io-lifetimes 1.0.3",
  "libc",
- "linux-raw-sys 0.1.2",
+ "linux-raw-sys 0.1.4",
  "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "same-file"
@@ -2223,9 +2230,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
 name = "security-framework"
@@ -2252,24 +2259,24 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2278,9 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2435,9 +2442,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2527,18 +2534,18 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2598,12 +2605,12 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
 dependencies = [
  "autocfg",
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "libc",
  "memchr",
  "mio",
@@ -2613,14 +2620,14 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2643,7 +2650,7 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
 dependencies = [
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "futures-core",
  "futures-io",
  "futures-sink",
@@ -2658,7 +2665,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
 dependencies = [
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
@@ -2668,9 +2675,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
 ]
@@ -2766,9 +2773,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucd-trie"
@@ -2784,9 +2791,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-normalization"
@@ -2975,9 +2982,9 @@ checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.19.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9424cdab516a16d4ea03c8f4a01b14e7b2d04a129dcc2bcdde5bcc5f68f06c41"
+checksum = "05632e0a66a6ed8cca593c24223aabd6262f256c3693ad9822c315285f010614"
 dependencies = [
  "leb128",
 ]
@@ -3006,7 +3013,7 @@ dependencies = [
  "log",
  "object",
  "once_cell",
- "paste 1.0.9",
+ "paste 1.0.11",
  "psm",
  "rayon",
  "serde",
@@ -3155,8 +3162,8 @@ dependencies = [
  "log",
  "mach",
  "memfd",
- "memoffset",
- "paste 1.0.9",
+ "memoffset 0.6.5",
+ "paste 1.0.11",
  "rand",
  "rustix 0.35.13",
  "thiserror",
@@ -3203,9 +3210,9 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "49.0.0"
+version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ef81fcd60d244cafffeafac3d17615fdb2fddda6aca18f34a8ae233353587c"
+checksum = "a2cbb59d4ac799842791fe7e806fa5dbbf6b5554d538e51cc8e176db6ff0ae34"
 dependencies = [
  "leb128",
  "memchr",
@@ -3215,11 +3222,11 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c347c4460ffb311e95aafccd8c29e4888f241b9e4b3bb0e0ccbd998de2c8c0d"
+checksum = "584aaf7a1ecf4d383bbe1a25eeab0cbb8ff96acc6796707ff65cde48f4632f15"
 dependencies = [
- "wast 49.0.0",
+ "wast 50.0.0",
 ]
 
 [[package]]
@@ -3499,9 +3506,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.1+zstd.1.5.2"
+version = "2.0.4+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
+checksum = "4fa202f2ef00074143e219d15b62ffc317d17cc33909feac471c044087cad7b0"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,7 @@ dependencies = [
  "assemblylift-core-io-common 0.3.0",
  "assemblylift-core-iomod",
  "crossbeam-channel",
+ "itertools",
  "once_cell",
  "tokio",
  "wasmtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,11 +146,7 @@ dependencies = [
  "tar",
  "toml",
  "walkdir",
- "wasmer",
- "wasmer-compiler",
- "wasmer-compiler-cranelift",
- "wasmer-compiler-singlepass",
- "wasmer-engine-universal",
+ "wasmtime",
  "z85",
  "zip",
 ]
@@ -1037,32 +1033,6 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
-]
-
-[[package]]
-name = "dynasm"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add9a102807b524ec050363f09e06f1504214b0e1c7797f64261c891022dce8b"
-dependencies = [
- "bitflags",
- "byteorder",
- "lazy_static",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "dynasmrt"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64fba5a42bd76a17cad4bfa00de168ee1cbfa06a5e8ce992ae880218c05641a9"
-dependencies = [
- "byteorder",
- "dynasm",
- "memmap2",
 ]
 
 [[package]]
@@ -3413,25 +3383,6 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "tracing",
- "wasmer-compiler",
- "wasmer-types",
-]
-
-[[package]]
-name = "wasmer-compiler-singlepass"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ca2a35204d8befa85062bc7aac259a8db8070b801b8a783770ba58231d729e"
-dependencies = [
- "byteorder",
- "dynasm",
- "dynasmrt",
- "gimli",
- "lazy_static",
- "loupe",
- "more-asserts",
- "rayon",
- "smallvec",
  "wasmer-compiler",
  "wasmer-types",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.64"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9a8f622bcf6ff3df478e9deba3e03e4e04b300f8e6a139e192c05fa3490afc7"
+checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
 name = "arrayvec"
@@ -108,12 +108,12 @@ dependencies = [
 
 [[package]]
 name = "assemblylift-awslambda-host"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.10"
 dependencies = [
  "assemblylift-core",
  "assemblylift-core-io-common 0.3.0",
  "assemblylift-core-iomod",
- "clap 3.2.20",
+ "clap 3.2.23",
  "crossbeam-channel",
  "once_cell",
  "reqwest",
@@ -130,8 +130,8 @@ dependencies = [
  "asml-iomod-registry-common",
  "assemblylift-core",
  "assemblylift-core-iomod",
- "base64 0.13.0",
- "bytes 1.1.0",
+ "base64 0.13.1",
+ "bytes 1.2.1",
  "clap 2.34.0",
  "dialoguer",
  "flate2",
@@ -267,8 +267,8 @@ dependencies = [
  "anyhow",
  "assemblylift-core",
  "assemblylift-core-iomod",
- "base64 0.13.0",
- "clap 3.2.20",
+ "base64 0.13.1",
+ "clap 3.2.23",
  "crossbeam-channel",
  "crossbeam-utils",
  "hyper",
@@ -346,15 +346,15 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64ct"
-version = "1.0.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a32fd6af2b5827bce66c29053ba0e7c42b9dcab01835835058558c10851a46b"
+checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
 
 [[package]]
 name = "bincode"
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.0"
+version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "bytecheck"
@@ -430,9 +430,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "bzip2"
@@ -522,15 +522,15 @@ dependencies = [
 
 [[package]]
 name = "capnp"
-version = "0.14.9"
+version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1b5dbbbfbae370eb9e9e86fb86b572acf4d5e0072e44636758cae3fe6ba6015"
+checksum = "ddf2d33bdc66ac282c34d34ecc9f8d8f1d82d1540994c5f8ed1c36dd0f95aaf3"
 
 [[package]]
 name = "capnp-futures"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a15248c8facb189a3c5fee74fbf1ff3adc134261d27da663b89c7d19ebaf983"
+checksum = "9821801cc6f199a9d9c3c793504e800c797b536d2befddaffb15144e40a6e63a"
 dependencies = [
  "capnp",
  "futures",
@@ -558,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
 dependencies = [
  "jobserver",
 ]
@@ -573,9 +573,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
  "num-integer",
@@ -609,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.20"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
  "bitflags",
@@ -620,7 +620,7 @@ dependencies = [
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
- "textwrap 0.15.0",
+ "textwrap 0.16.0",
 ]
 
 [[package]]
@@ -633,14 +633,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.15.1"
+name = "codespan-reporting"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "console"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
 dependencies = [
  "encode_unicode",
+ "lazy_static",
  "libc",
- "once_cell",
  "terminal_size",
  "unicode-width",
  "winapi",
@@ -888,26 +898,24 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
+checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
  "memoffset",
- "once_cell",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
+checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -921,10 +929,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.13.4"
+name = "cxx"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+checksum = "97abf9f0eca9e52b7f81b945524e76710e6cb2366aead23b7d4fbf72e281f888"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cc32cc5fea1d894b77d269ddb9f192110069a8a9c1f1d441195fba90553dea3"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca220e4794c934dc6b1207c3b42856ad4c302f2df1712e9f8d2eec5afaacf1f"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b846f081361125bfc8dc9d3940c84e1fd83ba54bbca7b17cd29483c828be0704"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -932,9 +984,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.13.4"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
 dependencies = [
  "fnv",
  "ident_case",
@@ -945,9 +997,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.13.4"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
  "darling_core",
  "quote",
@@ -976,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.3",
  "crypto-common",
@@ -1078,18 +1130,18 @@ dependencies = [
 
 [[package]]
 name = "enumset"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4799cdb24d48f1f8a7a98d06b7fde65a85a2d1e42b25a889f5406aa1fbefe074"
+checksum = "19be8061a06ab6f3a6cf21106c873578bf01bd42ad15e0311a9c76161cb1c753"
 dependencies = [
  "enumset_derive",
 ]
 
 [[package]]
 name = "enumset_derive"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea83a3fbdc1d999ccfbcbee717eab36f8edf2d71693a23ce0d7cca19e085304c"
+checksum = "03e7b551eba279bf0fa88b83a46330168c1560a52a94f5126f892f0b364ab3e0"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1158,14 +1210,14 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94a7bbaa59354bc20dd75b67f23e2797b4490e9d6928203fb105c79e448c86c"
+checksum = "4b9663d381d07ae25dc88dbdf27df458faa83a9b25336bcac83d5e452b5fc9d3"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "windows-sys 0.36.1",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1201,11 +1253,10 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "matches",
  "percent-encoding",
 ]
 
@@ -1222,9 +1273,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
+checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1237,9 +1288,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1247,15 +1298,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
+checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1264,15 +1315,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1281,21 +1332,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
 
 [[package]]
 name = "futures-task"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
 name = "futures-util"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1330,9 +1381,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1352,11 +1403,11 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
+checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1431,7 +1482,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -1440,7 +1491,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "fnv",
  "itoa",
 ]
@@ -1451,7 +1502,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "http",
  "pin-project-lite",
 ]
@@ -1476,11 +1527,11 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.20"
+version = "0.14.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1504,7 +1555,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "hyper",
  "native-tls",
  "tokio",
@@ -1513,16 +1564,26 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.47"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c495f162af0bf17656d0014a0eded5f3cd2f365fdd204548c2869db89359dc7"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
+ "iana-time-zone-haiku",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
  "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
 ]
 
 [[package]]
@@ -1533,20 +1594,19 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
- "matches",
  "unicode-bidi",
  "unicode-normalization",
 ]
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
@@ -1594,9 +1654,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
 
 [[package]]
 name = "is-terminal"
@@ -1612,24 +1672,24 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "ittapi"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "663fe0550070071ff59e981864a9cd3ee1c869ed0a088140d9ac4dc05ea6b1a1"
+checksum = "e8c4f6ff06169ce7048dac5150b1501c7e3716a929721aeb06b87e51a43e42f4"
 dependencies = [
  "anyhow",
  "ittapi-sys",
@@ -1638,27 +1698,27 @@ dependencies = [
 
 [[package]]
 name = "ittapi-sys"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e21911b7183f38c71d75ab478a527f314e28db51027037ece2e5511ed9410703"
+checksum = "87e078cce01485f418bae3beb34dd604aaedf2065502853c7da17fbce8e64eda"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.59"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1694,12 +1754,21 @@ checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "libloading"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1716,9 +1785,9 @@ checksum = "bb68f22743a3fb35785f1e7f844ca5a3de2dde5bd0c0ef5b372065814699b121"
 
 [[package]]
 name = "lock_api"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f80bf5aacaf25cbfc8210d1cfb718f2bf3b11c4c54e5afe36c236853a8ec390"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1773,12 +1842,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matches"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
-
-[[package]]
 name = "maybe-owned"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1801,9 +1864,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498"
+checksum = "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc"
 dependencies = [
  "libc",
 ]
@@ -1834,14 +1897,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.36.1",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1852,9 +1915,9 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "native-tls"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1889,20 +1952,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
  "hermit-abi 0.1.19",
- "libc",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
  "libc",
 ]
 
@@ -1932,9 +1986,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.14.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "opaque-debug"
@@ -1944,9 +1998,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.41"
+version = "0.10.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
+checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1976,9 +2030,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.75"
+version = "0.9.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
+checksum = "b03b84c3b2d099b81f0953422b4d4ad58761589d0229b5506356afca05a3670a"
 dependencies = [
  "autocfg",
  "cc",
@@ -1989,9 +2043,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.0"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+checksum = "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
 
 [[package]]
 name = "parking_lot"
@@ -2005,15 +2059,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.36.1",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2070,23 +2124,23 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.6",
  "hmac",
  "password-hash",
- "sha2 0.10.5",
+ "sha2 0.10.6",
 ]
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0560d531d1febc25a3c9398a62a71256c0178f2e3443baedd9ad4bb8c9deb4"
+checksum = "a528564cc62c19a7acac4d81e01f39e53e25e17b934878f4c6d25cc2836e62f8"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2094,9 +2148,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "905708f7f674518498c1f8d644481440f476d39ca6ecae83319bba7c6c12da91"
+checksum = "d5fd9bc6500181952d34bd0b2b0163a54d794227b498be0b7afa7698d0a7b18f"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2104,9 +2158,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5803d8284a629cc999094ecd630f55e91b561a1d1ba75e233b00ae13b91a69ad"
+checksum = "d2610d5ac5156217b4ff8e46ddcef7cdf44b273da2ac5bca2ecbfa86a330e7c4"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2117,13 +2171,13 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1538eb784f07615c6d9a8ab061089c6c54a344c5b4301db51990ca1c241e8c04"
+checksum = "824749bf7e21dd66b36fbe26b3f45c713879cccd4a009a917ab8e045ca8246fe"
 dependencies = [
  "once_cell",
  "pest",
- "sha-1",
+ "sha1",
 ]
 
 [[package]]
@@ -2140,9 +2194,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "ppv-lite86"
@@ -2182,9 +2236,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
@@ -2256,9 +2310,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
@@ -2332,9 +2386,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2352,9 +2406,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.27"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "region"
@@ -2388,12 +2442,12 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.11"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
+checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
- "base64 0.13.0",
- "bytes 1.1.0",
+ "base64 0.13.1",
+ "bytes 1.2.1",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -2404,10 +2458,10 @@ dependencies = [
  "hyper-tls",
  "ipnet",
  "js-sys",
- "lazy_static",
  "log",
  "mime",
  "native-tls",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "serde",
@@ -2537,6 +2591,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "scratch"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+
+[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2567,15 +2627,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
@@ -2591,9 +2651,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2602,9 +2662,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2625,25 +2685,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.3",
-]
-
-[[package]]
 name = "sha1"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006769ba83e921b3085caa8334186b00cf92b4cb1a6cf4632fbccc8eff5c7549"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.3",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -2661,13 +2710,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9db03534dff993187064c4e0c05a5708d2a9728ace9a8959b77bedf415dac5"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.3",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -2714,9 +2763,9 @@ checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
 
 [[package]]
 name = "smallvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
@@ -2742,9 +2791,9 @@ checksum = "8207e78455ffdf55661170876f88daf85356e4edd54e0a3dbc79586ca1e50cbe"
 
 [[package]]
 name = "stfu8"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "019f0c664fd85d5a87dcfb62b40b691055392a35a6e59f4df83d4b770db7e876"
+checksum = "1310970b29733b601839578f8ba24991a97057dbedc4ac0decea835474054ee7"
 dependencies = [
  "lazy_static",
  "regex",
@@ -2770,9 +2819,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2808,9 +2857,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02424087780c9b71cc96799eaeddff35af2bc513278cda5c99fc1f5d026d3c1"
+checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
 
 [[package]]
 name = "tempfile"
@@ -2856,24 +2905,24 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.34"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1b05ca9d106ba7d2e31a9dab4a64e7be2cce415321966ea3132c49a656e252"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.34"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2891,21 +2940,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.14"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
+checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
  "itoa",
- "libc",
- "num_threads",
+ "serde",
+ "time-core",
  "time-macros",
 ]
 
 [[package]]
-name = "time-macros"
-version = "0.2.4"
+name = "time-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+dependencies = [
+ "time-core",
+]
 
 [[package]]
 name = "tinyvec"
@@ -2924,17 +2982,16 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.0"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89797afd69d206ccd11fb0ea560a44bbb87731d020670e79416d442919257d42"
+checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
  "autocfg",
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "libc",
  "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -2970,7 +3027,7 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "futures-core",
  "futures-io",
  "futures-sink",
@@ -2985,7 +3042,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
@@ -3010,9 +3067,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "log",
@@ -3023,9 +3080,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3034,9 +3091,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -3111,30 +3168,30 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-width"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "url"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22fe195a4f217c25b25cb5058ced57059824a678474874038dc88d211bf508d3"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -3236,9 +3293,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3246,9 +3303,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 dependencies = [
  "bumpalo",
  "log",
@@ -3261,9 +3318,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
+checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3273,9 +3330,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3283,9 +3340,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3296,9 +3353,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "wasm-encoder"
@@ -3602,7 +3659,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42bd53d27df1076100519b680b45d8209aed62b4bbaf0913732810cb216f7b2b"
 dependencies = [
  "anyhow",
- "base64 0.13.0",
+ "base64 0.13.1",
  "bincode",
  "directories-next",
  "file-per-thread-logger",
@@ -3788,9 +3845,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.59"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -32,13 +32,14 @@ walkdir = "2.3"
 z85 = "3"
 zip = "0.6"
 
-wasmer = "2.1.1"
-wasmer-compiler = "2.1.1"
-wasmer-compiler-cranelift = "2.1.1"
-wasmer-compiler-singlepass = "2.1.1"
-wasmer-engine-universal = "2.1.1"
+#wasmer = "2.1.1"
+#wasmer-compiler = "2.1.1"
+#wasmer-compiler-cranelift = "2.1.1"
+#wasmer-compiler-singlepass = "2.1.1"
+#wasmer-engine-universal = "2.1.1"
+wasmtime = "2.0"
 
-assemblylift-core = { version = "0.4.0-alpha.3", path = "../core" }
+assemblylift-core = { version = "0.4.0-alpha.10", path = "../core" }
 assemblylift-core-iomod = { version = "0.4.0-alpha.0", path = "../core/iomod" }
 
 registry_common = { version = "0.1", package = "asml-iomod-registry-common" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -32,11 +32,6 @@ walkdir = "2.3"
 z85 = "3"
 zip = "0.6"
 
-#wasmer = "2.1.1"
-#wasmer-compiler = "2.1.1"
-#wasmer-compiler-cranelift = "2.1.1"
-#wasmer-compiler-singlepass = "2.1.1"
-#wasmer-engine-universal = "2.1.1"
 wasmtime = "2.0"
 
 assemblylift-core = { version = "0.4.0-alpha.10", path = "../core" }

--- a/cli/src/commands/cast/mod.rs
+++ b/cli/src/commands/cast/mod.rs
@@ -7,12 +7,6 @@ use clap::ArgMatches;
 use path_abs::PathInfo;
 use registry_common::models::GetIomodAtResponse;
 use reqwest;
-use wasmer::{Module, Store};
-use wasmer_compiler::{CpuFeature, Target, Triple};
-use wasmer_compiler_cranelift::Cranelift;
-//use wasmer_compiler_llvm::LLVM;
-//use wasmer_engine_native::Native;
-use wasmer_engine_universal::Universal;
 
 use crate::archive;
 use crate::projectfs::Project;

--- a/cli/src/commands/cast/ruby.rs
+++ b/cli/src/commands/cast/ruby.rs
@@ -65,11 +65,11 @@ pub fn compile(project: Rc<Project>, service_name: &str, function: &Function) ->
         std::fs::rename(ruby_bin.clone(), ruby_wasm.clone()).unwrap();
     }
     let mut ruby_wasmu = ruby_bin.clone();
-    ruby_wasmu.set_extension("wasmu");
+    ruby_wasmu.set_extension("wasm.bin");
     if !Path::new(&ruby_wasmu).exists() {
-        wasm::precompile(PathBuf::from(ruby_wasm)).unwrap();
+        wasm::precompile(Path::new(&ruby_wasm), "x86_64-linux-gnu").unwrap();
     }
-    let copy_to = format!("{}/ruby.wasmu", function_artifact_path.clone());
+    let copy_to = format!("{}/ruby.wasm.bin", function_artifact_path.clone());
     let copy_result = std::fs::copy(ruby_wasmu.clone(), copy_to.clone());
     if copy_result.is_err() {
         println!(

--- a/cli/src/commands/cast/rust.rs
+++ b/cli/src/commands/cast/rust.rs
@@ -1,5 +1,5 @@
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
 use assemblylift_core::wasm;
@@ -66,5 +66,5 @@ pub fn compile(project: Rc<Project>, service_name: &str, function: &Function) ->
         panic!("{:?}", copy_result.err());
     }
 
-    wasm::precompile(PathBuf::from(copy_to)).unwrap()
+    wasm::precompile(Path::new(&copy_to), "x86_64-linux-gnu").unwrap()
 }

--- a/cli/src/providers/aws_lambda.rs
+++ b/cli/src/providers/aws_lambda.rs
@@ -386,9 +386,9 @@ impl Castable for LambdaFunction {
                     service_name: service.clone(),
                     function_name: function.name.clone(),
                     handler_name: match function.language.as_str() {
-                        "rust" => format!("{}.wasmu", function.name.clone()),
-                        "ruby" => "ruby.wasmu".into(),
-                        _ => "handler".into(),
+                        "rust" => format!("{}.wasm.bin", function.name.clone()),
+                        "ruby" => "ruby.wasm.bin".into(),
+                        _ => "handler.wasm.bin".into(),
                     },
                     runtime_layer: format!(
                         "aws_lambda_layer_version.asml_{}_runtime.arn",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assemblylift-core"
-version = "0.4.0-alpha.3"
+version = "0.4.0-alpha.10"
 description = "AssemblyLift core library"
 authors = ["Akkoro and the AssemblyLift contributors <assemblylift@akkoro.io>"]
 edition = "2018"
@@ -15,8 +15,8 @@ once_cell = "1.4"
 tokio = "1.4"
 z85 = "3"
 
-wasmer = "2.1.1"
-wasmer-wasi = "2.1.1"
+wasmtime = "2.0"
+wasmtime-wasi = "2.0"
 
 assemblylift-core-io-common = { version = "0.3", path = "./io/common" }
 assemblylift-core-iomod = { version = "0.4.0-alpha.0", path = "./iomod" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 [dependencies]
 anyhow = "1.0"
 crossbeam-channel = "0.5"
+itertools = "0.10"
 once_cell = "1.4"
 tokio = "1.4"
 z85 = "3"

--- a/core/io/guest/Cargo.toml
+++ b/core/io/guest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assemblylift-core-io-guest"
-version = "0.4.0-alpha.0"
+version = "0.4.0-alpha.10"
 description = "AssemblyLift core event WASM guest library"
 authors = ["Akkoro and the AssemblyLift contributors <assemblylift@akkoro.io>"]
 edition = "2018"

--- a/core/io/guest/src/lib.rs
+++ b/core/io/guest/src/lib.rs
@@ -26,10 +26,6 @@ extern "C" {
     fn __asml_abi_input_start() -> i32;
     fn __asml_abi_input_next() -> i32;
     fn __asml_abi_input_length_get() -> u64;
-
-    // Z85
-    fn __asml_expabi_z85_encode(ptr: *const u8, len: usize, out_ptr: *const u8) -> i32;
-    fn __asml_expabi_z85_decode(ptr: *const u8, len: usize, out_ptr: *const u8) -> i32;
 }
 
 #[doc(hidden)]
@@ -83,7 +79,7 @@ impl std::io::Read for IoDocument {
         let mut bytes_read = 0usize;
         if self.bytes_read < self.length {
             for idx in 0..std::cmp::min(self.length, buf.len()) {
-                // unsafe: bytes_read is always positive, mod IO_BUFFER_SIZE_BYTES
+                // unsafe: bytes_read is always positive modulo IO_BUFFER_SIZE_BYTES
                 //         is always less than IO_BUFFER_SIZE_BYTES
                 buf[idx] = unsafe { IO_BUFFER[self.bytes_read % IO_BUFFER_SIZE_BYTES] };
                 bytes_read += 1;

--- a/core/io/guest/src/lib.rs
+++ b/core/io/guest/src/lib.rs
@@ -8,7 +8,6 @@ use serde::{de::DeserializeOwned, Deserialize};
 
 use assemblylift_core_io_common::constants::{FUNCTION_INPUT_BUFFER_SIZE, IO_BUFFER_SIZE_BYTES};
 
-/// The ABI exported by the AssemblyLift runtime host
 extern "C" {
     // IO
     fn __asml_abi_io_poll(id: u32) -> i32;

--- a/core/src/abi.rs
+++ b/core/src/abi.rs
@@ -2,6 +2,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use wasmtime::{Caller, Val};
 
+use itertools::Itertools;
+
 use crate::buffers::PagedWasmBuffer;
 use crate::wasm::{State, Wasmtime};
 
@@ -71,10 +73,15 @@ where
         state.threader.lock().unwrap().document_load(memory_offset, id).unwrap()
     };
     let memory = caller.get_export("memory").unwrap().into_memory().unwrap();
-    for e in data {
-        memory.write(&mut caller, e.0, &[e.1]).expect("");
+    match data.len() > 0 {
+        true => {
+            let offset = data[0].0;
+            let buffer = data.iter().map(|e| e.1).collect_vec();
+            memory.write(&mut caller, offset, &buffer).expect("");
+            0
+        }
+        false => -1,
     }
-    0
 }
 
 pub fn asml_abi_io_next<S>(mut caller: Caller<'_, State<S>>) -> i32
@@ -96,10 +103,15 @@ where
         state.threader.lock().unwrap().document_next(memory_offset).unwrap()
     };
     let memory = caller.get_export("memory").unwrap().into_memory().unwrap();
-    for e in data {
-        memory.write(&mut caller, e.0, &[e.1]).expect("");
+    match data.len() > 0 {
+        true => {
+            let offset = data[0].0;
+            let buffer = data.iter().map(|e| e.1).collect_vec();
+            memory.write(&mut caller, offset, &buffer).expect("");
+            0
+        }
+        false => -1,
     }
-    0
 }
 
 pub fn asml_abi_clock_time_get<S>(_caller: Caller<'_, State<S>>) -> u64
@@ -128,13 +140,19 @@ where
     let offset = ptr as usize;
     let data = {
         let state = caller.data_mut();
-        state.function_input_buffer.first(Some(vec![offset]))
+        state.function_input_buffer.first(0, offset)
     };
     let memory = caller.get_export("memory").unwrap().into_memory().unwrap();
-    for e in data {
-        memory.write(&mut caller, e.0, &[e.1]).expect("");
+    match data.len() > 0 {
+        true => {
+            let offset = data[0].0;
+            let buffer = data.iter().map(|e| e.1).collect_vec();
+            memory.write(&mut caller, offset, &buffer).expect("");
+            0
+        }
+        false => -1,
     }
-    0
+
 }
 
 pub fn asml_abi_input_next<S>(mut caller: Caller<'_, State<S>>) -> i32
@@ -154,13 +172,18 @@ where
     let offset = ptr as usize;
     let data = {
         let state = caller.data_mut();
-        state.function_input_buffer.next(Some(vec![offset]))
+        state.function_input_buffer.next(offset)
     };
     let memory = caller.get_export("memory").unwrap().into_memory().unwrap();
-    for e in data {
-        memory.write(&mut caller, e.0, &[e.1]).expect("");
+    match data.len() > 0 {
+        true => {
+            let offset = data[0].0;
+            let buffer = data.iter().map(|e| e.1).collect_vec();
+            memory.write(&mut caller, offset, &buffer).expect("");
+            0
+        }
+        false => -1,
     }
-    0
 }
 
 pub fn asml_abi_input_length_get<S>(mut caller: Caller<'_, State<S>>) -> u64

--- a/core/src/abi.rs
+++ b/core/src/abi.rs
@@ -82,7 +82,11 @@ where
             .document_load(memory_offset, id)
             .unwrap()
     };
-    let memory = caller.get_export("memory").unwrap().into_memory().unwrap();
+    let memory = caller
+        .get_export("memory")
+        .expect("could not find the default memory export named \"memory\"")
+        .into_memory()
+        .unwrap();
     match data.len() > 0 {
         true => {
             let offset = data[0].0;
@@ -122,7 +126,11 @@ where
             .document_next(memory_offset)
             .unwrap()
     };
-    let memory = caller.get_export("memory").unwrap().into_memory().unwrap();
+    let memory = caller
+        .get_export("memory")
+        .expect("could not find the default memory export named \"memory\"")
+        .into_memory()
+        .unwrap();
     match data.len() > 0 {
         true => {
             let offset = data[0].0;
@@ -167,7 +175,11 @@ where
         let state = caller.data_mut();
         state.function_input_buffer.first(0, offset)
     };
-    let memory = caller.get_export("memory").unwrap().into_memory().unwrap();
+    let memory = caller
+        .get_export("memory")
+        .expect("could not find the default memory export named \"memory\"")
+        .into_memory()
+        .unwrap();
     match data.len() > 0 {
         true => {
             let offset = data[0].0;
@@ -201,7 +213,11 @@ where
         let state = caller.data_mut();
         state.function_input_buffer.next(offset)
     };
-    let memory = caller.get_export("memory").unwrap().into_memory().unwrap();
+    let memory = caller
+        .get_export("memory")
+        .expect("could not find the default memory export named \"memory\"")
+        .into_memory()
+        .unwrap();
     match data.len() > 0 {
         true => {
             let offset = data[0].0;

--- a/core/src/abi.rs
+++ b/core/src/abi.rs
@@ -1,10 +1,6 @@
-use std::cell::Cell;
-use std::error::Error;
-use std::io;
-use std::io::ErrorKind;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use wasmtime::Caller;
+use wasmtime::{Caller, Val};
 
 use crate::buffers::{LinearBuffer, PagedWasmBuffer};
 use crate::wasm::{State, Wasmtime};
@@ -26,184 +22,136 @@ where
     S: Clone + Send + Sized + 'static,
 {
     if let Ok(method_path) = Wasmtime::<R, S>::ptr_to_string(&mut caller, name_ptr, name_len) {
-        if let Ok(input) = Wasmtime::<R, S>::ptr_to_bytes(&mut caller, input_ptr, input_len) {
-            return invoke_io(caller, &*method_path, input);
+        if let Ok(method_input) = Wasmtime::<R, S>::ptr_to_bytes(&mut caller, input_ptr, input_len)
+        {
+            return invoke_io(caller, &*method_path, method_input);
         }
     }
 
     -1i32 // error
 }
 
-// pub fn asml_abi_io_poll<S>(env: &ThreaderEnv<S>, id: u32) -> i32
-// where
-//     S: Clone + Send + Sized + 'static,
-// {
-//     env.threader.clone().lock().unwrap().poll(id) as i32
-// }
-//
-// pub fn asml_abi_io_len<S>(env: &ThreaderEnv<S>, id: u32) -> u32
-// where
-//     S: Clone + Send + Sized + 'static,
-// {
-//     env.threader
-//         .clone()
-//         .lock()
-//         .unwrap()
-//         .get_io_memory_document(id)
-//         .unwrap()
-//         .length as u32
-// }
-//
-// pub fn asml_abi_io_load<S>(env: &ThreaderEnv<S>, id: u32) -> i32
-// where
-//     S: Clone + Send + Sized + 'static,
-// {
-//     match env.threader.lock().unwrap().document_load(env, id) {
-//         Ok(_) => 0,
-//         Err(_) => -1,
-//     }
-// }
-//
-// pub fn asml_abi_io_next<S>(env: &ThreaderEnv<S>) -> i32
-// where
-//     S: Clone + Send + Sized + 'static,
-// {
-//     match env.threader.lock().unwrap().document_next(env) {
-//         Ok(_) => 0,
-//         Err(_) => -1,
-//     }
-// }
-//
-// pub fn asml_abi_clock_time_get<S>(_env: &ThreaderEnv<S>) -> u64
-// where
-//     S: Clone + Send + Sized + 'static,
-// {
-//     let start = SystemTime::now();
-//     let unix_time = start.duration_since(UNIX_EPOCH).expect("time is broken");
-//     unix_time.as_secs() * 1000u64
-// }
-//
+pub fn asml_abi_io_poll<S>(mut caller: Caller<'_, State<S>>, id: u32) -> i32
+where
+    S: Clone + Send + Sized + 'static,
+{
+    let state = caller.data_mut();
+    state.threader.clone().lock().unwrap().poll(id) as i32
+}
+
+pub fn asml_abi_io_len<S>(mut caller: Caller<'_, State<S>>, id: u32) -> u32
+where
+    S: Clone + Send + Sized + 'static,
+{
+    let state = caller.data_mut();
+    state
+        .threader
+        .clone()
+        .lock()
+        .unwrap()
+        .get_io_memory_document(id)
+        .unwrap()
+        .length as u32
+}
+
+pub fn asml_abi_io_load<S>(mut caller: Caller<'_, State<S>>, id: u32) -> i32
+where
+    S: Clone + Send + Sized + 'static,
+{
+    let state = caller.data_mut();
+    let io_buffer_ptr = state.io_buffer_ptr.unwrap();
+
+    let mut ptr: Vec<Val> = vec![Val::I32(0)];
+    io_buffer_ptr.call(&mut caller, &[], &mut ptr).expect("");
+    let ptr = *&ptr[0].i32().unwrap();
+
+    let memory_offset = ptr as usize;
+    let state = caller.data_mut();
+    match state
+        .threader
+        .lock()
+        .unwrap()
+        .document_load(state.memory_writer.clone(), memory_offset, id)
+    {
+        Ok(_) => 0,
+        Err(_) => -1,
+    }
+}
+
+pub fn asml_abi_io_next<S>(mut caller: Caller<'_, State<S>>) -> i32
+where
+    S: Clone + Send + Sized + 'static,
+{
+    let state = caller.data_mut();
+    let io_buffer_ptr = state.io_buffer_ptr.unwrap();
+
+    let mut ptr: Vec<Val> = vec![Val::I32(0)];
+    io_buffer_ptr.call(&mut caller, &[], &mut ptr).expect("");
+    let ptr = *&ptr[0].i32().unwrap();
+
+    let memory_offset = ptr as usize;
+    let state = caller.data_mut();
+    match state
+        .threader
+        .lock()
+        .unwrap()
+        .document_next(state.memory_writer.clone(), memory_offset)
+    {
+        Ok(_) => 0,
+        Err(_) => -1,
+    }
+}
+
+pub fn asml_abi_clock_time_get<S>(_caller: Caller<'_, State<S>>) -> u64
+where
+    S: Clone + Send + Sized + 'static,
+{
+    let start = SystemTime::now();
+    let unix_time = start.duration_since(UNIX_EPOCH).expect("time is broken");
+    unix_time.as_secs() * 1000u64
+}
+
 pub fn asml_abi_input_start<S>(mut caller: Caller<'_, State<S>>) -> i32
 where
     S: Clone + Send + Sized + 'static,
 {
-    // env.host_input_buffer
-    //     .clone()
-    //     .lock()
-    //     .unwrap()
-    //     .first(env, None)
     let state = caller.data_mut();
-    state.function_input_buffer.first(state.memory_writer.clone(), None)
+
+    let mut ptr: Vec<Val> = vec![Val::I32(0)];
+    state.function_input_buffer_ptr.unwrap().call(&mut caller, &[], &mut ptr).expect("");
+    let ptr = *&ptr[0].i32().unwrap();
+
+    let offset = ptr as usize;
+    let state = caller.data_mut();
+    state
+        .function_input_buffer
+        .first(state.memory_writer.clone(), Some(vec![offset]))
 }
-//
-// pub fn asml_abi_input_next<S>(env: &ThreaderEnv<S>) -> i32
-// where
-//     S: Clone + Send + Sized + 'static,
-// {
-//     env.host_input_buffer.clone().lock().unwrap().next(env)
-// }
-//
-// pub fn asml_abi_input_length_get<S>(env: &ThreaderEnv<S>) -> u64
-// where
-//     S: Clone + Send + Sized + 'static,
-// {
-//     env.host_input_buffer.clone().lock().unwrap().len() as u64
-// }
-//
-// pub fn asml_abi_z85_encode<S>(
-//     env: &ThreaderEnv<S>,
-//     ptr: u32,
-//     len: u32,
-//     out_ptr: WasmPtr<u8, Array>,
-// ) -> i32
-// where
-//     S: Clone + Send + Sized + 'static,
-// {
-//     if let Ok(input) = env_ptr_to_bytes(env, ptr, len) {
-//         let output = z85::encode(input);
-//         return match write_bytes_to_ptr(env, output.into_bytes(), out_ptr) {
-//             Ok(_) => 0i32,
-//             Err(_) => -1i32,
-//         };
-//     }
-//     -1i32
-// }
-//
-// pub fn asml_abi_z85_decode<S>(
-//     env: &ThreaderEnv<S>,
-//     ptr: u32,
-//     len: u32,
-//     out_ptr: WasmPtr<u8, Array>,
-// ) -> i32
-// where
-//     S: Clone + Send + Sized + 'static,
-// {
-//     if let Ok(input) = env_ptr_to_bytes(env, ptr, len) {
-//         if let Ok(output) = z85::decode(input) {
-//             return match write_bytes_to_ptr(env, output, out_ptr) {
-//                 Ok(_) => 0i32,
-//                 Err(_) => -1i32,
-//             };
-//         }
-//     }
-//     -1i32
-// }
-//
-// fn env_ptr_to_string<S>(env: &ThreaderEnv<S>, ptr: u32, len: u32) -> Result<String, io::Error>
-// where
-//     S: Clone + Send + Sized + 'static,
-// {
-//     let mem = env.memory_ref().unwrap();
-//     let view: MemoryView<u8> = mem.view();
-//
-//     let mut str_vec: Vec<u8> = Vec::new();
-//     for byte in view[ptr as usize..(ptr + len) as usize]
-//         .iter()
-//         .map(Cell::get)
-//     {
-//         str_vec.push(byte);
-//     }
-//
-//     std::str::from_utf8(str_vec.as_slice())
-//         .map(String::from)
-//         .map_err(to_io_error)
-// }
-//
-// fn write_bytes_to_ptr<S>(
-//     env: &ThreaderEnv<S>,
-//     s: Vec<u8>,
-//     ptr: WasmPtr<u8, Array>,
-// ) -> Result<(), io::Error>
-// where
-//     S: Clone + Send + Sized + 'static,
-// {
-//     let mem = env.memory_ref().unwrap();
-//     let memory_writer = ptr
-//         .deref(&mem, 0u32, s.len() as u32)
-//         .expect("could not deref wasm memory");
-//     for (i, b) in s.iter().enumerate() {
-//         memory_writer[i].set(*b);
-//     }
-//     Ok(())
-// }
-//
-// fn env_ptr_to_bytes<S>(env: &ThreaderEnv<S>, ptr: u32, len: u32) -> Result<Vec<u8>, io::Error>
-// where
-//     S: Clone + Send + Sized + 'static,
-// {
-//     let mem = env.memory_ref().unwrap();
-//     let view: MemoryView<u8> = mem.view();
-//
-//     let mut bytes: Vec<u8> = Vec::new();
-//     for byte in view[ptr as usize..(ptr + len) as usize]
-//         .iter()
-//         .map(Cell::get)
-//     {
-//         bytes.push(byte);
-//     }
-//
-//     Ok(bytes)
-// }
+
+pub fn asml_abi_input_next<S>(mut caller: Caller<'_, State<S>>) -> i32
+where
+    S: Clone + Send + Sized + 'static,
+{
+    let state = caller.data_mut();
+
+    let mut ptr: Vec<Val> = vec![Val::I32(0)];
+    state.function_input_buffer_ptr.unwrap().call(&mut caller, &[], &mut ptr).expect("");
+    let ptr = *&ptr[0].i32().unwrap();
+
+    let offset = ptr as usize;
+    let state = caller.data_mut();
+    state
+        .function_input_buffer
+        .next(state.memory_writer.clone(), Some(vec![offset]))
+}
+
+pub fn asml_abi_input_length_get<S>(mut caller: Caller<'_, State<S>>) -> u64
+where
+    S: Clone + Send + Sized + 'static,
+{
+    let state = caller.data_mut();
+    state.function_input_buffer.len() as u64
+}
 
 #[inline(always)]
 /// Invoke an IOmod call at coordinates `method_path` with input `method_input`

--- a/core/src/abi.rs
+++ b/core/src/abi.rs
@@ -2,7 +2,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use wasmtime::{Caller, Val};
 
-use crate::buffers::{LinearBuffer, PagedWasmBuffer};
+use crate::buffers::PagedWasmBuffer;
 use crate::wasm::{State, Wasmtime};
 
 pub trait RuntimeAbi<S: Clone + Send + Sized + 'static> {

--- a/core/src/abi.rs
+++ b/core/src/abi.rs
@@ -3,18 +3,20 @@ use std::error::Error;
 use std::io;
 use std::io::ErrorKind;
 use std::time::{SystemTime, UNIX_EPOCH};
+use wasmtime::Caller;
 
-use wasmer::{Array, MemoryView, WasmPtr};
+// use wasmer::{Array, MemoryView, WasmPtr};
 
 use crate::buffers::{LinearBuffer, PagedWasmBuffer};
-use crate::threader::ThreaderEnv;
-use crate::{invoke_io, WasmBufferPtr};
+// use crate::threader::ThreaderEnv;
+// use crate::{invoke_io, WasmBufferPtr};
+use crate::wasm::{State, Wasmtime};
 
-pub type AsmlAbiFn<S> = fn(&ThreaderEnv<S>, WasmBufferPtr, WasmBufferPtr, u32) -> i32;
+// pub type AsmlAbiFn<S> = fn(&ThreaderEnv<S>, WasmBufferPtr, WasmBufferPtr, u32) -> i32;
 
 pub trait RuntimeAbi<S: Clone + Send + Sized + 'static> {
-    fn log(env: &ThreaderEnv<S>, ptr: u32, len: u32);
-    fn success(env: &ThreaderEnv<S>, ptr: u32, len: u32);
+    fn log(caller: Caller<'_, State<S>>, ptr: u32, len: u32);
+    fn success(caller: Caller<'_, State<S>>, ptr: u32, len: u32);
 }
 
 fn to_io_error<E: Error>(err: E) -> io::Error {
@@ -22,7 +24,8 @@ fn to_io_error<E: Error>(err: E) -> io::Error {
 }
 
 pub fn asml_abi_io_invoke<S>(
-    env: &ThreaderEnv<S>,
+    // env: &ThreaderEnv<S>,
+    mut caller: Caller<'_, State<S>>,
     name_ptr: u32,
     name_len: u32,
     input: u32,
@@ -31,180 +34,180 @@ pub fn asml_abi_io_invoke<S>(
 where
     S: Clone + Send + Sized + 'static,
 {
-    if let Ok(method_path) = env_ptr_to_string(env, name_ptr, name_len) {
-        if let Ok(input) = env_ptr_to_bytes(env, input, input_len) {
-            return invoke_io(env, &*method_path, input);
+    if let Ok(method_path) = Wasmtime::ptr_to_string(&mut caller, name_ptr, name_len) {
+        if let Ok(input) = Wasmtime::ptr_to_bytes(&mut caller, input, input_len) {
+            // return invoke_io(env, &*method_path, input);
         }
     }
 
     -1i32 // error
 }
 
-pub fn asml_abi_io_poll<S>(env: &ThreaderEnv<S>, id: u32) -> i32
-where
-    S: Clone + Send + Sized + 'static,
-{
-    env.threader.clone().lock().unwrap().poll(id) as i32
-}
-
-pub fn asml_abi_io_len<S>(env: &ThreaderEnv<S>, id: u32) -> u32
-where
-    S: Clone + Send + Sized + 'static,
-{
-    env.threader
-        .clone()
-        .lock()
-        .unwrap()
-        .get_io_memory_document(id)
-        .unwrap()
-        .length as u32
-}
-
-pub fn asml_abi_io_load<S>(env: &ThreaderEnv<S>, id: u32) -> i32
-where
-    S: Clone + Send + Sized + 'static,
-{
-    match env.threader.lock().unwrap().document_load(env, id) {
-        Ok(_) => 0,
-        Err(_) => -1,
-    }
-}
-
-pub fn asml_abi_io_next<S>(env: &ThreaderEnv<S>) -> i32
-where
-    S: Clone + Send + Sized + 'static,
-{
-    match env.threader.lock().unwrap().document_next(env) {
-        Ok(_) => 0,
-        Err(_) => -1,
-    }
-}
-
-pub fn asml_abi_clock_time_get<S>(_env: &ThreaderEnv<S>) -> u64
-where
-    S: Clone + Send + Sized + 'static,
-{
-    let start = SystemTime::now();
-    let unix_time = start.duration_since(UNIX_EPOCH).expect("time is broken");
-    unix_time.as_secs() * 1000u64
-}
-
-pub fn asml_abi_input_start<S>(env: &ThreaderEnv<S>) -> i32
-where
-    S: Clone + Send + Sized + 'static,
-{
-    env.host_input_buffer
-        .clone()
-        .lock()
-        .unwrap()
-        .first(env, None)
-}
-
-pub fn asml_abi_input_next<S>(env: &ThreaderEnv<S>) -> i32
-where
-    S: Clone + Send + Sized + 'static,
-{
-    env.host_input_buffer.clone().lock().unwrap().next(env)
-}
-
-pub fn asml_abi_input_length_get<S>(env: &ThreaderEnv<S>) -> u64
-where
-    S: Clone + Send + Sized + 'static,
-{
-    env.host_input_buffer.clone().lock().unwrap().len() as u64
-}
-
-pub fn asml_abi_z85_encode<S>(
-    env: &ThreaderEnv<S>,
-    ptr: u32,
-    len: u32,
-    out_ptr: WasmPtr<u8, Array>,
-) -> i32
-where
-    S: Clone + Send + Sized + 'static,
-{
-    if let Ok(input) = env_ptr_to_bytes(env, ptr, len) {
-        let output = z85::encode(input);
-        return match write_bytes_to_ptr(env, output.into_bytes(), out_ptr) {
-            Ok(_) => 0i32,
-            Err(_) => -1i32,
-        };
-    }
-    -1i32
-}
-
-pub fn asml_abi_z85_decode<S>(
-    env: &ThreaderEnv<S>,
-    ptr: u32,
-    len: u32,
-    out_ptr: WasmPtr<u8, Array>,
-) -> i32
-where
-    S: Clone + Send + Sized + 'static,
-{
-    if let Ok(input) = env_ptr_to_bytes(env, ptr, len) {
-        if let Ok(output) = z85::decode(input) {
-            return match write_bytes_to_ptr(env, output, out_ptr) {
-                Ok(_) => 0i32,
-                Err(_) => -1i32,
-            };
-        }
-    }
-    -1i32
-}
-
-fn env_ptr_to_string<S>(env: &ThreaderEnv<S>, ptr: u32, len: u32) -> Result<String, io::Error>
-where
-    S: Clone + Send + Sized + 'static,
-{
-    let mem = env.memory_ref().unwrap();
-    let view: MemoryView<u8> = mem.view();
-
-    let mut str_vec: Vec<u8> = Vec::new();
-    for byte in view[ptr as usize..(ptr + len) as usize]
-        .iter()
-        .map(Cell::get)
-    {
-        str_vec.push(byte);
-    }
-
-    std::str::from_utf8(str_vec.as_slice())
-        .map(String::from)
-        .map_err(to_io_error)
-}
-
-fn write_bytes_to_ptr<S>(
-    env: &ThreaderEnv<S>,
-    s: Vec<u8>,
-    ptr: WasmPtr<u8, Array>,
-) -> Result<(), io::Error>
-where
-    S: Clone + Send + Sized + 'static,
-{
-    let mem = env.memory_ref().unwrap();
-    let memory_writer = ptr
-        .deref(&mem, 0u32, s.len() as u32)
-        .expect("could not deref wasm memory");
-    for (i, b) in s.iter().enumerate() {
-        memory_writer[i].set(*b);
-    }
-    Ok(())
-}
-
-fn env_ptr_to_bytes<S>(env: &ThreaderEnv<S>, ptr: u32, len: u32) -> Result<Vec<u8>, io::Error>
-where
-    S: Clone + Send + Sized + 'static,
-{
-    let mem = env.memory_ref().unwrap();
-    let view: MemoryView<u8> = mem.view();
-
-    let mut bytes: Vec<u8> = Vec::new();
-    for byte in view[ptr as usize..(ptr + len) as usize]
-        .iter()
-        .map(Cell::get)
-    {
-        bytes.push(byte);
-    }
-
-    Ok(bytes)
-}
+// pub fn asml_abi_io_poll<S>(env: &ThreaderEnv<S>, id: u32) -> i32
+// where
+//     S: Clone + Send + Sized + 'static,
+// {
+//     env.threader.clone().lock().unwrap().poll(id) as i32
+// }
+//
+// pub fn asml_abi_io_len<S>(env: &ThreaderEnv<S>, id: u32) -> u32
+// where
+//     S: Clone + Send + Sized + 'static,
+// {
+//     env.threader
+//         .clone()
+//         .lock()
+//         .unwrap()
+//         .get_io_memory_document(id)
+//         .unwrap()
+//         .length as u32
+// }
+//
+// pub fn asml_abi_io_load<S>(env: &ThreaderEnv<S>, id: u32) -> i32
+// where
+//     S: Clone + Send + Sized + 'static,
+// {
+//     match env.threader.lock().unwrap().document_load(env, id) {
+//         Ok(_) => 0,
+//         Err(_) => -1,
+//     }
+// }
+//
+// pub fn asml_abi_io_next<S>(env: &ThreaderEnv<S>) -> i32
+// where
+//     S: Clone + Send + Sized + 'static,
+// {
+//     match env.threader.lock().unwrap().document_next(env) {
+//         Ok(_) => 0,
+//         Err(_) => -1,
+//     }
+// }
+//
+// pub fn asml_abi_clock_time_get<S>(_env: &ThreaderEnv<S>) -> u64
+// where
+//     S: Clone + Send + Sized + 'static,
+// {
+//     let start = SystemTime::now();
+//     let unix_time = start.duration_since(UNIX_EPOCH).expect("time is broken");
+//     unix_time.as_secs() * 1000u64
+// }
+//
+// pub fn asml_abi_input_start<S>(env: &ThreaderEnv<S>) -> i32
+// where
+//     S: Clone + Send + Sized + 'static,
+// {
+//     env.host_input_buffer
+//         .clone()
+//         .lock()
+//         .unwrap()
+//         .first(env, None)
+// }
+//
+// pub fn asml_abi_input_next<S>(env: &ThreaderEnv<S>) -> i32
+// where
+//     S: Clone + Send + Sized + 'static,
+// {
+//     env.host_input_buffer.clone().lock().unwrap().next(env)
+// }
+//
+// pub fn asml_abi_input_length_get<S>(env: &ThreaderEnv<S>) -> u64
+// where
+//     S: Clone + Send + Sized + 'static,
+// {
+//     env.host_input_buffer.clone().lock().unwrap().len() as u64
+// }
+//
+// pub fn asml_abi_z85_encode<S>(
+//     env: &ThreaderEnv<S>,
+//     ptr: u32,
+//     len: u32,
+//     out_ptr: WasmPtr<u8, Array>,
+// ) -> i32
+// where
+//     S: Clone + Send + Sized + 'static,
+// {
+//     if let Ok(input) = env_ptr_to_bytes(env, ptr, len) {
+//         let output = z85::encode(input);
+//         return match write_bytes_to_ptr(env, output.into_bytes(), out_ptr) {
+//             Ok(_) => 0i32,
+//             Err(_) => -1i32,
+//         };
+//     }
+//     -1i32
+// }
+//
+// pub fn asml_abi_z85_decode<S>(
+//     env: &ThreaderEnv<S>,
+//     ptr: u32,
+//     len: u32,
+//     out_ptr: WasmPtr<u8, Array>,
+// ) -> i32
+// where
+//     S: Clone + Send + Sized + 'static,
+// {
+//     if let Ok(input) = env_ptr_to_bytes(env, ptr, len) {
+//         if let Ok(output) = z85::decode(input) {
+//             return match write_bytes_to_ptr(env, output, out_ptr) {
+//                 Ok(_) => 0i32,
+//                 Err(_) => -1i32,
+//             };
+//         }
+//     }
+//     -1i32
+// }
+//
+// fn env_ptr_to_string<S>(env: &ThreaderEnv<S>, ptr: u32, len: u32) -> Result<String, io::Error>
+// where
+//     S: Clone + Send + Sized + 'static,
+// {
+//     let mem = env.memory_ref().unwrap();
+//     let view: MemoryView<u8> = mem.view();
+//
+//     let mut str_vec: Vec<u8> = Vec::new();
+//     for byte in view[ptr as usize..(ptr + len) as usize]
+//         .iter()
+//         .map(Cell::get)
+//     {
+//         str_vec.push(byte);
+//     }
+//
+//     std::str::from_utf8(str_vec.as_slice())
+//         .map(String::from)
+//         .map_err(to_io_error)
+// }
+//
+// fn write_bytes_to_ptr<S>(
+//     env: &ThreaderEnv<S>,
+//     s: Vec<u8>,
+//     ptr: WasmPtr<u8, Array>,
+// ) -> Result<(), io::Error>
+// where
+//     S: Clone + Send + Sized + 'static,
+// {
+//     let mem = env.memory_ref().unwrap();
+//     let memory_writer = ptr
+//         .deref(&mem, 0u32, s.len() as u32)
+//         .expect("could not deref wasm memory");
+//     for (i, b) in s.iter().enumerate() {
+//         memory_writer[i].set(*b);
+//     }
+//     Ok(())
+// }
+//
+// fn env_ptr_to_bytes<S>(env: &ThreaderEnv<S>, ptr: u32, len: u32) -> Result<Vec<u8>, io::Error>
+// where
+//     S: Clone + Send + Sized + 'static,
+// {
+//     let mem = env.memory_ref().unwrap();
+//     let view: MemoryView<u8> = mem.view();
+//
+//     let mut bytes: Vec<u8> = Vec::new();
+//     for byte in view[ptr as usize..(ptr + len) as usize]
+//         .iter()
+//         .map(Cell::get)
+//     {
+//         bytes.push(byte);
+//     }
+//
+//     Ok(bytes)
+// }

--- a/core/src/abi.rs
+++ b/core/src/abi.rs
@@ -66,40 +66,40 @@ where
     let ptr = *&ptr[0].i32().unwrap();
 
     let memory_offset = ptr as usize;
-    let state = caller.data_mut();
-    match state
-        .threader
-        .lock()
-        .unwrap()
-        .document_load(state.memory_writer.clone(), memory_offset, id)
-    {
-        Ok(_) => 0,
-        Err(_) => -1,
+    let data = {
+        let state = caller.data_mut();
+        state.threader.lock().unwrap().document_load(memory_offset, id).unwrap()
+    };
+    let memory = caller.get_export("memory").unwrap().into_memory().unwrap();
+    for e in data {
+        memory.write(&mut caller, e.0, &[e.1]).expect("");
     }
+    0
 }
 
 pub fn asml_abi_io_next<S>(mut caller: Caller<'_, State<S>>) -> i32
 where
     S: Clone + Send + Sized + 'static,
 {
-    let state = caller.data_mut();
-    let io_buffer_ptr = state.io_buffer_ptr.unwrap();
+    let ptr = {
+        let state = caller.data_mut();
+        let io_buffer_ptr = state.io_buffer_ptr.unwrap();
 
-    let mut ptr: Vec<Val> = vec![Val::I32(0)];
-    io_buffer_ptr.call(&mut caller, &[], &mut ptr).expect("");
-    let ptr = *&ptr[0].i32().unwrap();
+        let mut ptr: Vec<Val> = vec![Val::I32(0)];
+        io_buffer_ptr.call(&mut caller, &[], &mut ptr).expect("");
+        *&ptr[0].i32().unwrap()
+    };
 
     let memory_offset = ptr as usize;
-    let state = caller.data_mut();
-    match state
-        .threader
-        .lock()
-        .unwrap()
-        .document_next(state.memory_writer.clone(), memory_offset)
-    {
-        Ok(_) => 0,
-        Err(_) => -1,
+    let data = {
+        let state = caller.data_mut();
+        state.threader.lock().unwrap().document_next(memory_offset).unwrap()
+    };
+    let memory = caller.get_export("memory").unwrap().into_memory().unwrap();
+    for e in data {
+        memory.write(&mut caller, e.0, &[e.1]).expect("");
     }
+    0
 }
 
 pub fn asml_abi_clock_time_get<S>(_caller: Caller<'_, State<S>>) -> u64
@@ -118,14 +118,23 @@ where
     let state = caller.data_mut();
 
     let mut ptr: Vec<Val> = vec![Val::I32(0)];
-    state.function_input_buffer_ptr.unwrap().call(&mut caller, &[], &mut ptr).expect("");
+    state
+        .function_input_buffer_ptr
+        .unwrap()
+        .call(&mut caller, &[], &mut ptr)
+        .expect("");
     let ptr = *&ptr[0].i32().unwrap();
 
     let offset = ptr as usize;
-    let state = caller.data_mut();
-    state
-        .function_input_buffer
-        .first(state.memory_writer.clone(), Some(vec![offset]))
+    let data = {
+        let state = caller.data_mut();
+        state.function_input_buffer.first(Some(vec![offset]))
+    };
+    let memory = caller.get_export("memory").unwrap().into_memory().unwrap();
+    for e in data {
+        memory.write(&mut caller, e.0, &[e.1]).expect("");
+    }
+    0
 }
 
 pub fn asml_abi_input_next<S>(mut caller: Caller<'_, State<S>>) -> i32
@@ -135,14 +144,23 @@ where
     let state = caller.data_mut();
 
     let mut ptr: Vec<Val> = vec![Val::I32(0)];
-    state.function_input_buffer_ptr.unwrap().call(&mut caller, &[], &mut ptr).expect("");
+    state
+        .function_input_buffer_ptr
+        .unwrap()
+        .call(&mut caller, &[], &mut ptr)
+        .expect("");
     let ptr = *&ptr[0].i32().unwrap();
 
     let offset = ptr as usize;
-    let state = caller.data_mut();
-    state
-        .function_input_buffer
-        .next(state.memory_writer.clone(), Some(vec![offset]))
+    let data = {
+        let state = caller.data_mut();
+        state.function_input_buffer.next(Some(vec![offset]))
+    };
+    let memory = caller.get_export("memory").unwrap().into_memory().unwrap();
+    for e in data {
+        memory.write(&mut caller, e.0, &[e.1]).expect("");
+    }
+    0
 }
 
 pub fn asml_abi_input_length_get<S>(mut caller: Caller<'_, State<S>>) -> u64

--- a/core/src/abi.rs
+++ b/core/src/abi.rs
@@ -83,16 +83,18 @@ where
 //     unix_time.as_secs() * 1000u64
 // }
 //
-// pub fn asml_abi_input_start<S>(env: &ThreaderEnv<S>) -> i32
-// where
-//     S: Clone + Send + Sized + 'static,
-// {
-//     env.host_input_buffer
-//         .clone()
-//         .lock()
-//         .unwrap()
-//         .first(env, None)
-// }
+pub fn asml_abi_input_start<S>(mut caller: Caller<'_, State<S>>) -> i32
+where
+    S: Clone + Send + Sized + 'static,
+{
+    // env.host_input_buffer
+    //     .clone()
+    //     .lock()
+    //     .unwrap()
+    //     .first(env, None)
+    let state = caller.data_mut();
+    state.function_input_buffer.first(state.memory_writer.clone(), None)
+}
 //
 // pub fn asml_abi_input_next<S>(env: &ThreaderEnv<S>) -> i32
 // where

--- a/core/src/buffers.rs
+++ b/core/src/buffers.rs
@@ -26,7 +26,7 @@ impl FunctionInputBuffer {
         }
     }
 
-    pub fn initialize(&mut self, buffer: Vec<u8>) {
+    pub fn set(&mut self, buffer: Vec<u8>) {
         self.buffer = buffer;
     }
 

--- a/core/src/buffers.rs
+++ b/core/src/buffers.rs
@@ -125,31 +125,9 @@ impl WasmBuffer for FunctionInputBuffer {
         src: (usize, usize),
         dst: (usize, usize),
     ) -> Result<(), ()> {
-        // let memory = caller.get_export("memory").unwrap().into_memory().unwrap();
-        // let fib_fn = caller.get_export("__asml_guest_get_function_input_buffer_pointer").unwrap().into_func().unwrap();
-        //
-        // let offset: i32 = fib_fn
-        //     .typed::<(), i32, _>(&caller)
-        //     .expect("invalid FIB func typedef")
-        //     .call(&mut caller, ())
-        //     .expect("TODO: panic message");
-        // memory.write(&mut caller, offset as usize, &self.buffer[src.0..src.1])
-        //     .expect("TODO: panic message");
-        // let wasm_memory = env.memory_ref().unwrap();
-        // let input_buffer = env
-        //     .get_function_input_buffer
-        //     .get_ref()
-        //     .unwrap()
-        //     .call()
-        //     .unwrap();
-        // let memory_writer: Vec<WasmCell<u8>> = input_buffer
-        //     .deref(&wasm_memory, dst.0 as u32, dst.1 as u32)
-        //     .unwrap();
-        //
         for (i, b) in self.buffer[src.0..src.1].iter().enumerate() {
             let idx = i + dst.0;
             memory_writer.blocking_send((idx, *b)).unwrap();
-            // memory_writer[idx].set(*b);
         }
 
         Ok(())
@@ -248,23 +226,6 @@ impl WasmBuffer for IoBuffer {
         dst: (usize, usize),
     ) -> Result<(), ()> {
         use std::cmp::min;
-        // let memory = caller.get_export("memory").unwrap().into_memory().unwrap();
-        // let io_buffer_fn = caller.get_export("__asml_guest_get_io_buffer_pointer").unwrap().into_func().unwrap();
-
-        // let offset: i32 = io_buffer_fn
-        //     .typed::<(), i32, _>(&caller)
-        //     .expect("invalid iobuffer func typedef")
-        //     .call(&mut caller, ())
-        //     .expect("TODO: panic message");
-        // let buffer = self.buffers.get(&src.0).unwrap();
-        // memory.write(&mut caller, offset as usize, &buffer[src.1..min(src.1 + IO_BUFFER_SIZE_BYTES, buffer.len())])
-        //     .expect("TODO: panic message");
-        // let wasm_memory = env.memory_ref().unwrap();
-        // let io_buffer = env.get_io_buffer.get_ref().unwrap().call().unwrap();
-        // let memory_writer: Vec<WasmCell<u8>> = io_buffer
-        //     .deref(&wasm_memory, dst.0 as u32, dst.1 as u32)
-        //     .unwrap();
-
         let buffer = self.buffers.get(&src.0).unwrap();
         for (i, b) in buffer[src.1..min(src.1 + IO_BUFFER_SIZE_BYTES, buffer.len())]
             .iter()
@@ -272,7 +233,6 @@ impl WasmBuffer for IoBuffer {
         {
             let idx = i + dst.0;
             memory_writer.blocking_send((idx, *b)).unwrap();
-            // memory_writer[i].set(*b);
         }
 
         Ok(())

--- a/core/src/buffers.rs
+++ b/core/src/buffers.rs
@@ -85,24 +85,6 @@ impl IoBuffer {
         }
     }
 
-    pub fn len(&self, ioid: usize) -> usize {
-        self.buffers.get(&ioid).unwrap().len()
-    }
-
-    pub fn with_capacity(num_buffers: usize, buffer_capacity: usize) -> Self {
-        let mut buffers: HashMap<usize, Vec<u8>> = HashMap::new();
-        let mut indices: HashMap<usize, usize> = HashMap::new();
-        for idx in 0..num_buffers {
-            buffers.insert(idx, Vec::with_capacity(buffer_capacity));
-            indices.insert(idx, 0);
-        }
-        Self {
-            active_buffer: 0usize,
-            buffers,
-            page_indices: indices,
-        }
-    }
-
     pub fn write(&mut self, ioid: usize, bytes: &[u8]) -> usize {
         let mut bytes_written = 0usize;
         match self.buffers.get_mut(&ioid) {

--- a/core/src/buffers.rs
+++ b/core/src/buffers.rs
@@ -7,20 +7,6 @@ use assemblylift_core_io_common::constants::{FUNCTION_INPUT_BUFFER_SIZE, IO_BUFF
 
 use crate::wasm::BufferElement;
 
-/// A trait representing a linear byte buffer, such as Vec<u8>
-pub trait LinearBuffer {
-    /// Initialize the buffer with the contents of `buffer`
-    fn initialize(&mut self, buffer: Vec<u8>);
-    /// Write bytes to the buffer at an offset
-    fn write(&mut self, bytes: &[u8], at_offset: usize) -> usize;
-    /// Erase `len` bytes starting from `offset`
-    fn erase(&mut self, offset: usize, len: usize) -> usize;
-    /// The length of the buffer in bytes
-    fn len(&self) -> usize;
-    /// The capacity of the buffer in bytes
-    fn capacity(&self) -> usize;
-}
-
 /// Implement paging data into a `WasmBuffer`
 pub trait PagedWasmBuffer {
     fn first(&mut self, offset: Option<Vec<usize>>) -> Vec<BufferElement>;
@@ -39,37 +25,13 @@ impl FunctionInputBuffer {
             page_idx: 0usize,
         }
     }
-}
 
-impl LinearBuffer for FunctionInputBuffer {
-    fn initialize(&mut self, buffer: Vec<u8>) {
+    pub fn initialize(&mut self, buffer: Vec<u8>) {
         self.buffer = buffer;
     }
 
-    fn write(&mut self, bytes: &[u8], at_offset: usize) -> usize {
-        let mut bytes_written = 0usize;
-        for idx in at_offset..bytes.len() {
-            self.buffer[idx] = bytes[idx - at_offset];
-            bytes_written += 1;
-        }
-        bytes_written
-    }
-
-    fn erase(&mut self, offset: usize, len: usize) -> usize {
-        let mut bytes_erased = 0usize;
-        for idx in offset..len {
-            self.buffer[idx] = 0;
-            bytes_erased += 1;
-        }
-        bytes_erased
-    }
-
-    fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.buffer.len()
-    }
-
-    fn capacity(&self) -> usize {
-        self.buffer.capacity()
     }
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,34 +1,6 @@
-// use wasmer::{Array, WasmPtr};
-
-// use crate::threader::ThreaderEnv;
-
-// pub type WasmBufferPtr = WasmPtr<u8, Array>;
 pub use wasmtime::Caller;
 
 pub mod abi;
 pub mod buffers;
 pub mod threader;
 pub mod wasm;
-
-// #[inline(always)]
-// /// Invoke an IOmod call at coordinates `method_path` with input `method_input`
-// pub fn invoke_io<S>(env: &ThreaderEnv<S>, method_path: &str, method_input: Vec<u8>) -> i32
-// where
-//     S: Clone + Send + Sized + 'static,
-// {
-//     let ioid = env
-//         .threader
-//         .clone()
-//         .lock()
-//         .unwrap()
-//         .next_ioid()
-//         .expect("unable to get a new IO ID");
-//
-//     env.threader
-//         .clone()
-//         .lock()
-//         .unwrap()
-//         .invoke(method_path, method_input, ioid);
-//
-//     ioid as i32
-// }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,4 +1,4 @@
-pub use wasmtime::Caller;
+pub use wasmtime::{AsContextMut, Caller};
 
 pub mod abi;
 pub mod buffers;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,33 +1,34 @@
-use wasmer::{Array, WasmPtr};
+// use wasmer::{Array, WasmPtr};
 
-use crate::threader::ThreaderEnv;
+// use crate::threader::ThreaderEnv;
 
-pub type WasmBufferPtr = WasmPtr<u8, Array>;
+// pub type WasmBufferPtr = WasmPtr<u8, Array>;
+pub use wasmtime::Caller;
 
 pub mod abi;
 pub mod buffers;
 pub mod threader;
 pub mod wasm;
 
-#[inline(always)]
-/// Invoke an IOmod call at coordinates `method_path` with input `method_input`
-pub fn invoke_io<S>(env: &ThreaderEnv<S>, method_path: &str, method_input: Vec<u8>) -> i32
-where
-    S: Clone + Send + Sized + 'static,
-{
-    let ioid = env
-        .threader
-        .clone()
-        .lock()
-        .unwrap()
-        .next_ioid()
-        .expect("unable to get a new IO ID");
-
-    env.threader
-        .clone()
-        .lock()
-        .unwrap()
-        .invoke(method_path, method_input, ioid);
-
-    ioid as i32
-}
+// #[inline(always)]
+// /// Invoke an IOmod call at coordinates `method_path` with input `method_input`
+// pub fn invoke_io<S>(env: &ThreaderEnv<S>, method_path: &str, method_input: Vec<u8>) -> i32
+// where
+//     S: Clone + Send + Sized + 'static,
+// {
+//     let ioid = env
+//         .threader
+//         .clone()
+//         .lock()
+//         .unwrap()
+//         .next_ioid()
+//         .expect("unable to get a new IO ID");
+//
+//     env.threader
+//         .clone()
+//         .lock()
+//         .unwrap()
+//         .invoke(method_path, method_input, ioid);
+//
+//     ioid as i32
+// }

--- a/core/src/threader.rs
+++ b/core/src/threader.rs
@@ -11,7 +11,7 @@ use tokio::sync::mpsc;
 use assemblylift_core_iomod::registry::{RegistryChannelMessage, RegistryTx};
 
 use crate::buffers::{IoBuffer, PagedWasmBuffer};
-use crate::wasm::MemoryMessage;
+use crate::wasm::BufferElement;
 
 pub type IoId = u32;
 
@@ -58,27 +58,26 @@ where
     /// Load the memory document associated with `ioid` into the guest IO memory
     pub fn document_load(
         &mut self,
-        memory_writer: mpsc::Sender<MemoryMessage>,
         memory_offset: usize,
         ioid: IoId,
-    ) -> Result<(), ()> {
+    ) -> Result<Vec<BufferElement>, ()> {
         let doc = self.get_io_memory_document(ioid).unwrap();
-        self.io_memory
+        let data = self.io_memory
             .lock()
             .unwrap()
             .buffer
-            .first(memory_writer, Some(vec![doc.start, memory_offset]));
-        Ok(())
+            .first(Some(vec![doc.start, memory_offset]));
+        Ok(data)
     }
 
     /// Advance the guest IO memory to the next page
-    pub fn document_next(&mut self, memory_writer: mpsc::Sender<MemoryMessage>, memory_offset: usize) -> Result<(), ()> {
-        self.io_memory
+    pub fn document_next(&mut self, memory_offset: usize) -> Result<Vec<BufferElement>, ()> {
+        let data = self.io_memory
             .lock()
             .unwrap()
             .buffer
-            .next(memory_writer, Some(vec![memory_offset]));
-        Ok(())
+            .next(Some(vec![memory_offset]));
+        Ok(data)
     }
 
     /// Poll the runtime for the completion status of call associated with `ioid`

--- a/core/src/threader.rs
+++ b/core/src/threader.rs
@@ -66,7 +66,7 @@ where
             .lock()
             .unwrap()
             .buffer
-            .first(Some(vec![doc.start, memory_offset]));
+            .first(doc.start, memory_offset);
         Ok(data)
     }
 
@@ -76,7 +76,7 @@ where
             .lock()
             .unwrap()
             .buffer
-            .next(Some(vec![memory_offset]));
+            .next(memory_offset);
         Ok(data)
     }
 
@@ -205,7 +205,7 @@ impl IoMemory {
     }
 
     fn handle_response(&mut self, response: Vec<u8>, ioid: IoId) {
-        self.buffer.write(ioid as usize, response.as_slice());
+        self.buffer.set(ioid as usize, response.clone());
         self.io_status.insert(ioid, true);
         self.document_map.insert(
             ioid,

--- a/core/src/threader.rs
+++ b/core/src/threader.rs
@@ -13,7 +13,7 @@ use wasmtime::Caller;
 use assemblylift_core_iomod::registry::{RegistryChannelMessage, RegistryTx};
 
 use crate::buffers::{FunctionInputBuffer, IoBuffer, PagedWasmBuffer};
-use crate::wasm::State;
+use crate::wasm::{MemoryMessage, State};
 
 // use wasmer::{Array, LazyInit, Memory, NativeFunc, WasmPtr, WasmerEnv};
 
@@ -93,19 +93,19 @@ where
     }
 
     /// Load the memory document associated with `ioid` into the guest IO memory
-    pub fn document_load(&mut self, caller: Caller<'_, State<S>>, ioid: IoId) -> Result<(), ()> {
+    pub fn document_load(&mut self, memory_writer: mpsc::Sender<MemoryMessage>, ioid: IoId) -> Result<(), ()> {
         let doc = self.get_io_memory_document(ioid).unwrap();
         self.io_memory
             .lock()
             .unwrap()
             .buffer
-            .first(caller, Some(doc.start));
+            .first(memory_writer, Some(doc.start));
         Ok(())
     }
 
     /// Advance the guest IO memory to the next page
-    pub fn document_next(&mut self, caller: Caller<'_, State<S>>) -> Result<(), ()> {
-        self.io_memory.lock().unwrap().buffer.next(caller);
+    pub fn document_next(&mut self, memory_writer: mpsc::Sender<MemoryMessage>) -> Result<(), ()> {
+        self.io_memory.lock().unwrap().buffer.next(memory_writer);
         Ok(())
     }
 

--- a/core/src/threader.rs
+++ b/core/src/threader.rs
@@ -60,7 +60,7 @@ where
         &mut self,
         memory_offset: usize,
         ioid: IoId,
-    ) -> Result<Vec<BufferElement>, ()> {
+    ) -> anyhow::Result<Vec<BufferElement>> {
         let doc = self.get_io_memory_document(ioid).unwrap();
         let data = self.io_memory
             .lock()
@@ -71,7 +71,7 @@ where
     }
 
     /// Advance the guest IO memory to the next page
-    pub fn document_next(&mut self, memory_offset: usize) -> Result<Vec<BufferElement>, ()> {
+    pub fn document_next(&mut self, memory_offset: usize) -> anyhow::Result<Vec<BufferElement>> {
         let data = self.io_memory
             .lock()
             .unwrap()
@@ -89,6 +89,7 @@ where
                         // At this point, the document "contents" have already been written to the WASM buffer
                         //    and are read on the guest side immediately after poll() exits.
                         // We can free the host-side memory structure here.
+
                         //                        memory.free(ioid);
                         true
                     }

--- a/core/src/threader.rs
+++ b/core/src/threader.rs
@@ -15,39 +15,6 @@ use crate::wasm::MemoryMessage;
 
 pub type IoId = u32;
 
-// #[derive(WasmerEnv, Clone)]
-// /// The `WasmerEnv` environment providing shared data between native WASM functions and the host
-// pub struct ThreaderEnv<S>
-// where
-//     S: Clone + Send + Sized + 'static,
-// {
-//     pub threader: ManuallyDrop<Arc<Mutex<Threader<S>>>>,
-//     pub host_input_buffer: Arc<Mutex<FunctionInputBuffer>>,
-//     #[wasmer(export)]
-//     pub memory: LazyInit<Memory>,
-//     #[wasmer(export(name = "__asml_guest_get_function_input_buffer_pointer"))]
-//     pub get_function_input_buffer: LazyInit<NativeFunc<(), WasmPtr<u8, Array>>>,
-//     #[wasmer(export(name = "__asml_guest_get_io_buffer_pointer"))]
-//     pub get_io_buffer: LazyInit<NativeFunc<(), WasmPtr<u8, Array>>>,
-//     pub status_sender: crossbeam_channel::Sender<S>,
-// }
-//
-// impl<S> ThreaderEnv<S>
-// where
-//     S: Clone + Send + Sized + 'static,
-// {
-//     pub fn new(tx: RegistryTx, status_sender: crossbeam_channel::Sender<S>) -> Self {
-//         ThreaderEnv {
-//             threader: ManuallyDrop::new(Arc::new(Mutex::new(Threader::new(tx)))),
-//             memory: Default::default(),
-//             get_function_input_buffer: Default::default(),
-//             get_io_buffer: Default::default(),
-//             host_input_buffer: Arc::new(Mutex::new(FunctionInputBuffer::new())),
-//             status_sender,
-//         }
-//     }
-// }
-
 pub struct Threader<S> {
     io_memory: Arc<Mutex<IoMemory>>,
     registry_tx: RegistryTx,

--- a/core/src/wasm.rs
+++ b/core/src/wasm.rs
@@ -1,3 +1,4 @@
+use std::fs::File;
 use std::io::Write;
 use std::mem::ManuallyDrop;
 use std::path::{Path, PathBuf};
@@ -5,7 +6,7 @@ use std::sync::{Arc, Mutex};
 
 use tokio::sync::mpsc;
 use wasmtime::{Caller, Config, Engine, Func, Instance, Linker, Module, Store};
-use wasmtime_wasi::{WasiCtx, WasiCtxBuilder};
+use wasmtime_wasi::{Dir, WasiCtx, WasiCtxBuilder};
 
 use assemblylift_core_iomod::registry::RegistryTx;
 
@@ -66,8 +67,39 @@ where
         let threader = ManuallyDrop::new(Arc::new(Mutex::new(Threader::new(registry_tx))));
         let mut linker: Linker<State<S>> = Linker::new(&self.engine);
 
+        let function_env = std::env::var("ASML_FUNCTION_ENV").unwrap_or("default".into());
+
         wasmtime_wasi::add_to_linker(&mut linker, |s| &mut s.wasi).expect("");
-        let wasi = WasiCtxBuilder::new().build();
+        let wasi = match function_env.as_str() {
+            "ruby-docker" => WasiCtxBuilder::new()
+                .arg("/src/handler.rb")
+                .unwrap()
+                .env("RUBY_PLATFORM", "wasm32-wasi")
+                .unwrap()
+                .preopened_dir(Dir::from_std_file(File::open("/usr/bin/ruby-wasm32-wasi/src").unwrap()), "/src")
+                .unwrap()
+                .preopened_dir(Dir::from_std_file(File::open("/usr/bin/ruby-wasm32-wasi/usr").unwrap()), "/usr")
+                .unwrap()
+                .preopened_dir(Dir::from_std_file(File::open("/tmp/asmltmp").unwrap()), "/tmp")
+                .unwrap()
+                .build(),
+            "ruby-lambda" => WasiCtxBuilder::new()
+                .arg("/src/handler.rb")
+                .unwrap()
+                .env("RUBY_PLATFORM", "wasm32-wasi")
+                .unwrap()
+                .preopened_dir(Dir::from_std_file(File::open("/tmp/rubysrc").unwrap()), "/src")
+                .unwrap()
+                .preopened_dir(Dir::from_std_file(File::open("/tmp/rubyusr").unwrap()), "/usr")
+                .unwrap()
+                .preopened_dir(Dir::from_std_file(File::open("/tmp/asmltmp").unwrap()), "/tmp")
+                .unwrap()
+                .build(),
+            _ => WasiCtxBuilder::new()
+                .preopened_dir(Dir::from_std_file(File::open("/tmp/asmltmp").unwrap()), "/tmp")
+                .unwrap()
+                .build()
+        };
 
         let state = State {
             function_input_buffer: FunctionInputBuffer::new(),
@@ -200,74 +232,6 @@ where
     wasi: WasiCtx,
 }
 
-// pub fn build_module<R, S>(
-//     registry_tx: RegistryTx,
-//     status_sender: crossbeam_channel::Sender<S>,
-//     module: Arc<Module>,
-//     module_name: &str,
-//     store: Arc<Store>,
-// ) -> anyhow::Result<(Resolver, ThreaderEnv<S>)>
-// where
-//     R: RuntimeAbi<S> + 'static,
-//     S: Clone + Send + Sized + 'static,
-// {
-//     let threader_env = ThreaderEnv::new(registry_tx, status_sender);
-//     let function_env = std::env::var("ASML_FUNCTION_ENV").unwrap_or("default".into());
-//     let mut wasi_env = match function_env.as_str() {
-//         "ruby-docker" => WasiState::new(module_name.clone())
-//             .arg("/src/handler.rb")
-//             .env("RUBY_PLATFORM", "wasm32-wasi")
-//             .map_dir("/src", "/usr/bin/ruby-wasm32-wasi/src")
-//             .expect("could not preopen `src` directory")
-//             .map_dir("/usr", "/usr/bin/ruby-wasm32-wasi/usr")
-//             .expect("could not map ruby fs")
-//             .finalize()
-//             .expect("could not init WASI env"),
-//         "ruby-lambda" => WasiState::new(module_name.clone())
-//             .arg("/src/handler.rb")
-//             .env("RUBY_PLATFORM", "wasm32-wasi")
-//             .map_dir("/src", "/tmp/rubysrc")
-//             .expect("could not preopen `src` directory")
-//             .map_dir("/usr", "/tmp/rubyusr")
-//             .expect("could not map ruby fs")
-//             .finalize()
-//             .expect("could not init WASI env"),
-//         _ => WasiState::new(module_name.clone())
-//             .finalize()
-//             .expect("could not init WASI env"),
-//     };
-//
-//     let wasi_imports = wasi_env
-//         .import_object(&module)
-//         .expect("could not get WASI import object");
-//     let asml_imports = imports! {
-//         "env" => {
-//             "__asml_abi_runtime_log" => Function::new_native_with_env(&store, threader_env.clone(), R::log),
-//             "__asml_abi_runtime_success" => Function::new_native_with_env(&store, threader_env.clone(), R::success),
-//
-//             "__asml_abi_invoke" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_io_invoke), // TODO deprecated, IOmod guests need to update
-//             "__asml_abi_io_invoke" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_io_invoke),
-//             "__asml_abi_io_poll" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_io_poll),
-//             "__asml_abi_io_len" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_io_len),
-//             "__asml_abi_io_load" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_io_load),
-//             "__asml_abi_io_next" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_io_next),
-//
-//             "__asml_abi_clock_time_get" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_clock_time_get),
-//
-//             "__asml_abi_input_start" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_input_start),
-//             "__asml_abi_input_next" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_input_next),
-//             "__asml_abi_input_length_get" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_input_length_get),
-//
-//             "__asml_expabi_z85_encode" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_z85_encode),
-//             "__asml_expabi_z85_decode" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_z85_decode),
-//         },
-//     };
-//
-//     let import_object: Resolver = asml_imports.chain_back(wasi_imports);
-//
-//     Ok((import_object, threader_env))
-// }
-
 pub fn precompile(module_path: &Path, target: &str) -> anyhow::Result<PathBuf> {
     // TODO compiler configuration
     let file_path = format!("{}.bin", module_path.display().to_string());
@@ -281,7 +245,7 @@ pub fn precompile(module_path: &Path, target: &str) -> anyhow::Result<PathBuf> {
     let compiled_bytes = engine
         .precompile_module(&*wasm_bytes)
         .expect("TODO: panic message");
-    let mut module_file = match std::fs::File::create(file_path.clone()) {
+    let mut module_file = match File::create(file_path.clone()) {
         Ok(file) => file,
         Err(err) => panic!("{}", err.to_string()),
     };

--- a/core/src/wasm.rs
+++ b/core/src/wasm.rs
@@ -10,7 +10,7 @@ use wasmtime_wasi::{WasiCtx, WasiCtxBuilder};
 use assemblylift_core_iomod::registry::RegistryTx;
 
 use crate::abi::*;
-use crate::buffers::{FunctionInputBuffer, LinearBuffer};
+use crate::buffers::FunctionInputBuffer;
 use crate::threader::Threader;
 
 pub type State<S> = AsmlFunctionState<S>;

--- a/core/src/wasm.rs
+++ b/core/src/wasm.rs
@@ -179,7 +179,7 @@ where
         store
             .data_mut()
             .function_input_buffer
-            .initialize(input.to_vec());
+            .set(input.to_vec());
         Ok(())
     }
 

--- a/core/src/wasm.rs
+++ b/core/src/wasm.rs
@@ -1,167 +1,233 @@
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use wasmer::{
-    imports, ChainableNamedResolver, CpuFeature, Cranelift, Function, ImportObject, Instance,
-    InstantiationError, Module, NamedResolverChain, Store, Target, Triple, Universal,
-};
-use wasmer_wasi::WasiState;
+use wasmtime::{AsContext, Caller, Engine, Linker, Module, Store};
+use wasmtime_wasi::{WasiCtx, WasiCtxBuilder};
 
 use assemblylift_core_iomod::registry::RegistryTx;
 
 use crate::abi::*;
-use crate::threader::ThreaderEnv;
+use crate::buffers::{FunctionInputBuffer, LinearBuffer};
+// use crate::threader::ThreaderEnv;
 
-pub type ModuleTreble<S> = (Module, Resolver, ThreaderEnv<S>);
-pub type Resolver = NamedResolverChain<ImportObject, ImportObject>;
+pub type State<S> = AsmlFunctionState<S>;
 
-pub fn deserialize_module_from_path<R, S>(
-    module_path: &str,
-    module_name: &str,
-) -> anyhow::Result<(Module, Store)>
+pub struct Wasmtime<S>
 where
-    R: RuntimeAbi<S> + 'static,
     S: Clone + Send + Sized + 'static,
 {
-    let file_path = format!("{}/{}", module_path, module_name);
-
-    let compiler = Cranelift::default();
-    let store = Store::new(&Universal::new(compiler).engine());
-    Ok((
-        unsafe { Module::deserialize_from_file(&store, file_path.clone()) }
-            .expect(&format!("could not load wasm from {}", file_path.clone())),
-        store,
-    ))
+    engine: Engine,
+    module: Module,
+    linker: Option<Linker<State<S>>>,
+    store: Option<Store<State<S>>>,
 }
 
-pub fn deserialize_module_from_bytes<R, S>(module_bytes: &[u8]) -> anyhow::Result<(Module, Store)>
+impl<S> Wasmtime<S>
 where
-    R: RuntimeAbi<S> + 'static,
     S: Clone + Send + Sized + 'static,
 {
-    let compiler = Cranelift::default();
-    let store = Store::new(&Universal::new(compiler).engine());
-    Ok((
-        unsafe { Module::deserialize(&store, module_bytes) }
-            .expect(&format!("could not load wasm from bytes")),
-        store,
-    ))
-}
+    pub fn new_from_path(module_path: &Path) -> anyhow::Result<Self> {
+        let engine = Engine::default();
+        let module = unsafe { Module::deserialize_file(&engine, module_path) }.expect("");
+        Ok(Self {
+            engine,
+            module,
+            linker: None,
+            store: None,
+        })
+    }
 
-pub fn build_module<R, S>(
-    registry_tx: RegistryTx,
-    status_sender: crossbeam_channel::Sender<S>,
-    module: Arc<Module>,
-    module_name: &str,
-    store: Arc<Store>,
-) -> anyhow::Result<(Resolver, ThreaderEnv<S>)>
-where
-    R: RuntimeAbi<S> + 'static,
-    S: Clone + Send + Sized + 'static,
-{
-    let threader_env = ThreaderEnv::new(registry_tx, status_sender);
-    let function_env = std::env::var("ASML_FUNCTION_ENV").unwrap_or("default".into());
-    let mut wasi_env = match function_env.as_str() {
-        "ruby-docker" => WasiState::new(module_name.clone())
-            .arg("/src/handler.rb")
-            .env("RUBY_PLATFORM", "wasm32-wasi")
-            .map_dir("/src", "/usr/bin/ruby-wasm32-wasi/src")
-            .expect("could not preopen `src` directory")
-            .map_dir("/usr", "/usr/bin/ruby-wasm32-wasi/usr")
-            .expect("could not map ruby fs")
-            .finalize()
-            .expect("could not init WASI env"),
-        "ruby-lambda" => WasiState::new(module_name.clone())
-            .arg("/src/handler.rb")
-            .env("RUBY_PLATFORM", "wasm32-wasi")
-            .map_dir("/src", "/tmp/rubysrc")
-            .expect("could not preopen `src` directory")
-            .map_dir("/usr", "/tmp/rubyusr")
-            .expect("could not map ruby fs")
-            .finalize()
-            .expect("could not init WASI env"),
-        _ => WasiState::new(module_name.clone())
-            .finalize()
-            .expect("could not init WASI env"),
-    };
+    pub fn new_from_bytes(module_bytes: &[u8]) -> anyhow::Result<Self> {
+        let engine = Engine::default();
+        let module = unsafe { Module::deserialize(&engine, module_bytes) }.expect("");
+        Ok(Self {
+            engine,
+            module,
+            linker: None,
+            store: None,
+        })
+    }
 
-    let wasi_imports = wasi_env
-        .import_object(&module)
-        .expect("could not get WASI import object");
-    let asml_imports = imports! {
-        "env" => {
-            "__asml_abi_runtime_log" => Function::new_native_with_env(&store, threader_env.clone(), R::log),
-            "__asml_abi_runtime_success" => Function::new_native_with_env(&store, threader_env.clone(), R::success),
+    pub fn link_module(
+        &mut self,
+        status_sender: crossbeam_channel::Sender<S>,
+    ) -> anyhow::Result<()> {
+        let mut linker: Linker<State<S>> = Linker::new(&self.engine);
+        wasmtime_wasi::add_to_linker(&mut linker, |s| &mut s.wasi).expect("");
+        let wasi = WasiCtxBuilder::new().build();
+        let state = State {
+            function_input_buffer: FunctionInputBuffer::new(),
+            status_sender,
+            wasi,
+        };
+        let mut store = Store::new(&self.engine, state);
 
-            "__asml_abi_invoke" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_io_invoke), // TODO deprecated, IOmod guests need to update
-            "__asml_abi_io_invoke" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_io_invoke),
-            "__asml_abi_io_poll" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_io_poll),
-            "__asml_abi_io_len" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_io_len),
-            "__asml_abi_io_load" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_io_load),
-            "__asml_abi_io_next" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_io_next),
+        linker.module(&mut store, "", &self.module).expect("");
+        linker
+            .func_wrap("", "__asml_abi_io_invoke", asml_abi_io_invoke::<S>)
+            .expect("");
 
-            "__asml_abi_clock_time_get" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_clock_time_get),
+        self.store = Some(store);
+        self.linker = Some(linker);
+        Ok(())
+    }
 
-            "__asml_abi_input_start" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_input_start),
-            "__asml_abi_input_next" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_input_next),
-            "__asml_abi_input_length_get" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_input_length_get),
+    pub fn initialize_function_input_buffer(&mut self, input: &[u8]) -> anyhow::Result<()> {
+        let store = self.store.as_mut().unwrap();
+        store
+            .data_mut()
+            .function_input_buffer
+            .initialize(input.to_vec());
+        Ok(())
+    }
 
-            "__asml_expabi_z85_encode" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_z85_encode),
-            "__asml_expabi_z85_decode" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_z85_decode),
-        },
-    };
+    pub fn start(&mut self) -> anyhow::Result<()> {
+        self.linker
+            .as_ref()
+            .expect("module not linked yet")
+            .get_default(self.store.as_mut().unwrap(), "")
+            .expect("could not find default function")
+            .typed::<(), (), _>(self.store.as_mut().unwrap())
+            .expect("invalid default function signature")
+            .call(self.store.as_mut().unwrap(), ())
+            .expect("could not call default function");
+        Ok(())
+    }
 
-    let import_object: Resolver = asml_imports.chain_back(wasi_imports);
+    pub fn ptr_to_string(mut caller: &mut Caller<'_, State<S>>, ptr: u32, len: u32) -> anyhow::Result<String> {
+        let bytes = Self::ptr_to_bytes(caller, ptr, len).unwrap();
+        let s = std::str::from_utf8(&bytes).unwrap();
+        Ok(s.into())
+    }
 
-    Ok((import_object, threader_env))
-}
-
-pub fn new_instance(
-    module: Arc<Module>,
-    import_object: Resolver,
-) -> Result<Instance, InstantiationError> {
-    Instance::new(&module, &import_object)
-}
-
-pub fn precompile(module_path: PathBuf) -> Result<PathBuf, &'static str> {
-    // TODO compiler configuration
-    let is_wasmu = module_path
-        .extension()
-        .unwrap_or("wasm".as_ref())
-        .eq("wasmu");
-    match is_wasmu {
-        false => {
-            let file_path = format!("{}u", module_path.as_path().display().to_string());
-            println!("Precompiling WASM to {}...", file_path.clone());
-
-            let compiler = Cranelift::default();
-            let triple = Triple::from_str("x86_64-unknown-unknown").unwrap();
-            let mut cpuid = CpuFeature::set();
-            cpuid.insert(CpuFeature::SSE2); // required for x86
-            let store = Store::new(
-                &/*Native*/Universal::new(compiler)
-                .target(Target::new(triple, cpuid))
-                .engine(),
-            );
-
-            let wasm_bytes = match std::fs::read(module_path.clone()) {
-                Ok(bytes) => bytes,
-                Err(err) => panic!("{}", err.to_string()),
-            };
-            let module = Module::new(&store, wasm_bytes).unwrap();
-            let module_bytes = module.serialize().unwrap();
-            let mut module_file = match std::fs::File::create(file_path.clone()) {
-                Ok(file) => file,
-                Err(err) => panic!("{}", err.to_string()),
-            };
-            println!("📄 > Wrote {}", &file_path);
-            module_file.write_all(&module_bytes).unwrap();
-
-            Ok(PathBuf::from(file_path))
-        }
-
-        true => Ok(module_path),
+    pub fn ptr_to_bytes(mut caller: &mut Caller<'_, State<S>>, ptr: u32, len: u32) -> anyhow::Result<Vec<u8>> {
+        let memory = caller
+            .get_export("memory")
+            .unwrap()
+            .into_memory()
+            .unwrap();
+        let mut buffer: Vec<u8> = vec![0; len as usize];
+        memory.read(&caller, ptr as usize, &mut buffer).unwrap();
+        Ok(buffer)
     }
 }
+
+pub struct AsmlFunctionState<S>
+where
+    S: Clone + Send + Sized + 'static,
+{
+    pub function_input_buffer: FunctionInputBuffer,
+    pub status_sender: crossbeam_channel::Sender<S>,
+    wasi: WasiCtx,
+}
+
+// pub fn build_module<R, S>(
+//     registry_tx: RegistryTx,
+//     status_sender: crossbeam_channel::Sender<S>,
+//     module: Arc<Module>,
+//     module_name: &str,
+//     store: Arc<Store>,
+// ) -> anyhow::Result<(Resolver, ThreaderEnv<S>)>
+// where
+//     R: RuntimeAbi<S> + 'static,
+//     S: Clone + Send + Sized + 'static,
+// {
+//     let threader_env = ThreaderEnv::new(registry_tx, status_sender);
+//     let function_env = std::env::var("ASML_FUNCTION_ENV").unwrap_or("default".into());
+//     let mut wasi_env = match function_env.as_str() {
+//         "ruby-docker" => WasiState::new(module_name.clone())
+//             .arg("/src/handler.rb")
+//             .env("RUBY_PLATFORM", "wasm32-wasi")
+//             .map_dir("/src", "/usr/bin/ruby-wasm32-wasi/src")
+//             .expect("could not preopen `src` directory")
+//             .map_dir("/usr", "/usr/bin/ruby-wasm32-wasi/usr")
+//             .expect("could not map ruby fs")
+//             .finalize()
+//             .expect("could not init WASI env"),
+//         "ruby-lambda" => WasiState::new(module_name.clone())
+//             .arg("/src/handler.rb")
+//             .env("RUBY_PLATFORM", "wasm32-wasi")
+//             .map_dir("/src", "/tmp/rubysrc")
+//             .expect("could not preopen `src` directory")
+//             .map_dir("/usr", "/tmp/rubyusr")
+//             .expect("could not map ruby fs")
+//             .finalize()
+//             .expect("could not init WASI env"),
+//         _ => WasiState::new(module_name.clone())
+//             .finalize()
+//             .expect("could not init WASI env"),
+//     };
+//
+//     let wasi_imports = wasi_env
+//         .import_object(&module)
+//         .expect("could not get WASI import object");
+//     let asml_imports = imports! {
+//         "env" => {
+//             "__asml_abi_runtime_log" => Function::new_native_with_env(&store, threader_env.clone(), R::log),
+//             "__asml_abi_runtime_success" => Function::new_native_with_env(&store, threader_env.clone(), R::success),
+//
+//             "__asml_abi_invoke" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_io_invoke), // TODO deprecated, IOmod guests need to update
+//             "__asml_abi_io_invoke" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_io_invoke),
+//             "__asml_abi_io_poll" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_io_poll),
+//             "__asml_abi_io_len" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_io_len),
+//             "__asml_abi_io_load" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_io_load),
+//             "__asml_abi_io_next" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_io_next),
+//
+//             "__asml_abi_clock_time_get" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_clock_time_get),
+//
+//             "__asml_abi_input_start" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_input_start),
+//             "__asml_abi_input_next" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_input_next),
+//             "__asml_abi_input_length_get" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_input_length_get),
+//
+//             "__asml_expabi_z85_encode" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_z85_encode),
+//             "__asml_expabi_z85_decode" => Function::new_native_with_env(&store, threader_env.clone(), asml_abi_z85_decode),
+//         },
+//     };
+//
+//     let import_object: Resolver = asml_imports.chain_back(wasi_imports);
+//
+//     Ok((import_object, threader_env))
+// }
+//
+// pub fn precompile(module_path: PathBuf) -> Result<PathBuf, &'static str> {
+//     // TODO compiler configuration
+//     let is_wasmu = module_path
+//         .extension()
+//         .unwrap_or("wasm".as_ref())
+//         .eq("wasmu");
+//     match is_wasmu {
+//         false => {
+//             let file_path = format!("{}u", module_path.as_path().display().to_string());
+//             println!("Precompiling WASM to {}...", file_path.clone());
+//
+//             let compiler = Cranelift::default();
+//             let triple = Triple::from_str("x86_64-unknown-unknown").unwrap();
+//             let mut cpuid = CpuFeature::set();
+//             cpuid.insert(CpuFeature::SSE2); // required for x86
+//             let store = Store::new(
+//                 &/*Native*/Universal::new(compiler)
+//                 .target(Target::new(triple, cpuid))
+//                 .engine(),
+//             );
+//
+//             let wasm_bytes = match std::fs::read(module_path.clone()) {
+//                 Ok(bytes) => bytes,
+//                 Err(err) => panic!("{}", err.to_string()),
+//             };
+//             let module = Module::new(&store, wasm_bytes).unwrap();
+//             let module_bytes = module.serialize().unwrap();
+//             let mut module_file = match std::fs::File::create(file_path.clone()) {
+//                 Ok(file) => file,
+//                 Err(err) => panic!("{}", err.to_string()),
+//             };
+//             println!("📄 > Wrote {}", &file_path);
+//             module_file.write_all(&module_bytes).unwrap();
+//
+//             Ok(PathBuf::from(file_path))
+//         }
+//
+//         true => Ok(module_path),
+//     }
+// }

--- a/docker/asml-hyper-alpine
+++ b/docker/asml-hyper-alpine
@@ -1,6 +1,6 @@
 # Builder
-#FROM rust:1.61-alpine3.16 as builder
-FROM rust:1.61-buster as builder
+#FROM rust:1.66-alpine3.16 as builder
+FROM rust:1.66-buster as builder
 #RUN rustup target add x86_64-unknown-linux-musl
 #RUN apk --no-cache add capnproto-dev musl-dev
 RUN apt-get update && apt-get install build-essential capnproto -y

--- a/runtimes/aws-lambda/host/Cargo.toml
+++ b/runtimes/aws-lambda/host/Cargo.toml
@@ -21,8 +21,6 @@ reqwest = { version = "0.11", features = ["blocking"] }
 toml = "0.5"
 zip = "0.6"
 
-wasmer = "2.1.1"
-
 assemblylift_core = { version = "0.4.0-alpha.10", package = "assemblylift-core", path = "../../../core" }
 assemblylift_core_iomod = { version = "0.4.0-alpha.0", package = "assemblylift-core-iomod", path = "../../../core/iomod" }
 assemblylift_core_io_common = { version = "0.3", package = "assemblylift-core-io-common", path = "../../../core/io/common" }

--- a/runtimes/aws-lambda/host/src/abi.rs
+++ b/runtimes/aws-lambda/host/src/abi.rs
@@ -1,52 +1,23 @@
 use assemblylift_core::abi::RuntimeAbi;
-use assemblylift_core::threader::ThreaderEnv;
-use std::cell::Cell;
-use std::error::Error;
-use std::io;
-use std::io::ErrorKind;
-use wasmer::MemoryView;
+use assemblylift_core::Caller;
+use assemblylift_core::wasm::{State, Wasmtime};
+
+pub type Status = ();
 
 pub struct LambdaAbi;
 
-impl<S> RuntimeAbi<S> for LambdaAbi
-where
-    S: Clone + Send + Sized + 'static,
-{
-    fn log(env: &ThreaderEnv<S>, ptr: u32, len: u32) {
-        let string = runtime_ptr_to_string(env, ptr, len).unwrap();
-        println!("LOG: {}", string);
+impl RuntimeAbi<Status> for LambdaAbi {
+    fn log(mut caller: Caller<'_, State<Status>>, ptr: u32, len: u32) {
+        let s = Wasmtime::<Self, Status>::ptr_to_string(&mut caller, ptr, len).unwrap();
+        println!("LOG: {}", s);
     }
 
-    fn success(env: &ThreaderEnv<S>, ptr: u32, len: u32) {
+    fn success(mut caller: Caller<'_, State<Status>>, ptr: u32, len: u32) {
         let lambda_runtime = &crate::LAMBDA_RUNTIME;
-        let response = runtime_ptr_to_string(env, ptr, len).unwrap();
-        let threader = env.threader.clone();
+        let response = Wasmtime::<Self, Status>::ptr_to_string(&mut caller, ptr, len).unwrap();
 
-        let respond = lambda_runtime.respond(response.to_string());
-        threader.lock().unwrap().spawn(respond);
+        let respond = lambda_runtime.respond(response);
+        let state = caller.data_mut();
+        state.threader.clone().lock().unwrap().spawn(respond);
     }
-}
-
-fn runtime_ptr_to_string<S>(env: &ThreaderEnv<S>, ptr: u32, len: u32) -> Result<String, io::Error>
-where
-    S: Clone + Send + Sized + 'static,
-{
-    let memory = env.memory_ref().unwrap();
-    let view: MemoryView<u8> = memory.view();
-
-    let mut str_vec: Vec<u8> = Vec::new();
-    for byte in view[ptr as usize..(ptr + len) as usize]
-        .iter()
-        .map(Cell::get)
-    {
-        str_vec.push(byte);
-    }
-
-    std::str::from_utf8(str_vec.as_slice())
-        .map(String::from)
-        .map_err(to_io_error)
-}
-
-fn to_io_error<E: Error>(err: E) -> io::Error {
-    io::Error::new(ErrorKind::Other, err.to_string())
 }

--- a/runtimes/aws-lambda/host/src/main.rs
+++ b/runtimes/aws-lambda/host/src/main.rs
@@ -14,8 +14,7 @@ use once_cell::sync::Lazy;
 use tokio::sync::mpsc;
 use zip;
 
-use assemblylift_core::buffers::LinearBuffer;
-use assemblylift_core::wasm;
+use assemblylift_core::wasm::Wasmtime;
 use assemblylift_core_iomod::{package::IomodManifest, registry};
 use runtime::AwsLambdaRuntime;
 
@@ -31,7 +30,7 @@ pub static LAMBDA_REQUEST_ID: Lazy<Mutex<RefCell<String>>> =
 #[tokio::main]
 async fn main() {
     println!(
-        "Starting AssemblyLift AWS Lambda runtime {}",
+        "Starting AssemblyLift AWS Lambda runtime v{}",
         crate_version!()
     );
 
@@ -46,8 +45,8 @@ async fn main() {
             let entry = entry.unwrap();
             println!("DEBUG entry={:?}", entry);
             if entry.file_type().unwrap().is_file() {
-                // this makes the assumption that the
-                // IOmod entrypoint is always an executable binary
+                // FIXME this makes the assumption that the
+                //       IOmod entrypoint is always an executable binary
                 if let Some(os_path) = entry.path().extension() {
                     if let Some(ext) = os_path.to_str() {
                         if ext == "iomod" {
@@ -109,8 +108,6 @@ async fn main() {
 
     let module_path = env::var("LAMBDA_TASK_ROOT").unwrap();
     let handler_name = env::var("_HANDLER").unwrap();
-    let parts = handler_name.split(".").collect::<Vec<&str>>();
-    let function_name = String::from(parts[0]);
 
     // Mapped to /tmp inside the WASM module
     fs::create_dir_all("/tmp/asmltmp").expect("could not create /tmp/asmltmp");
@@ -157,57 +154,48 @@ async fn main() {
 
     let (status_sender, _status_receiver) = bounded::<()>(1);
 
-    let task_set = tokio::task::LocalSet::new();
-    task_set
-        .run_until(async move {
-            let (module, store) = match wasm::deserialize_module_from_path::<LambdaAbi, ()>(
-                &module_path,
-                &handler_name,
-            ) {
-                Ok(module) => (Arc::new(module.0), Arc::new(module.1)),
-                Err(_) => panic!("PANIC this shouldn't happen"),
-            };
+    tokio::task::LocalSet::new().run_until(async move {
+        let mut full_path = PathBuf::from(&module_path);
+        full_path.push(&handler_name);
+        let wasmtime = Arc::new(Mutex::new(
+            Wasmtime::<LambdaAbi, ()>::new_from_path(Path::new(full_path.as_path()))
+                .expect("could not create WASM runtime from module path")
+        ));
 
-            while let Ok(event) = LAMBDA_RUNTIME.get_next_event().await {
-                {
-                    let ref_cell = LAMBDA_REQUEST_ID.lock().unwrap();
-                    if ref_cell.borrow().clone() == event.request_id.clone() {
-                        continue;
-                    }
-                    ref_cell.replace(event.request_id.clone());
+        while let Ok(event) = LAMBDA_RUNTIME.get_next_event().await {
+            {
+                let ref_cell = LAMBDA_REQUEST_ID.lock().unwrap();
+                if ref_cell.borrow().clone() == event.request_id.clone() {
+                    continue;
                 }
-
-                let (import_object, env) = wasm::build_module::<LambdaAbi, ()>(
-                    tx.clone(),
-                    status_sender.clone(),
-                    module.clone(),
-                    &function_name,
-                    store.clone(),
-                )
-                .expect("could not build WASM module");
-                // TODO we can save some cycles by creating Instances up-front in a pool & recycling them
-                let instance = match wasm::new_instance(module.clone(), import_object.clone()) {
-                    Ok(instance) => Arc::new(instance),
-                    Err(why) => panic!("PANIC {}", why.to_string()),
-                };
-                env.host_input_buffer
-                    .clone()
-                    .lock()
-                    .unwrap()
-                    .initialize(event.event_body.into_bytes());
-                tokio::task::spawn_local(async move {
-                    // env.clone().threader.lock().unwrap().__reset_memory();
-
-                    let handler_call = instance.exports.get_function("_start").unwrap();
-                    match handler_call.call(&[]) {
-                        Ok(result) => println!("SUCCESS: handler returned {:?}", result),
-                        Err(error) => println!("ERROR: {}", error.to_string()),
-                    }
-                })
-                .await
-                .unwrap();
-                // std::mem::drop(env.clone().threader);
+                ref_cell.replace(event.request_id.clone());
             }
-        })
-        .await;
+
+            let (instance, mut store) = wasmtime
+                .lock()
+                .unwrap()
+                .link_module(tx.clone(), status_sender.clone())
+                .expect("could not link wasm module");
+
+            wasmtime
+                .lock()
+                .unwrap()
+                .initialize_function_input_buffer(&mut store, &event.event_body.into_bytes())
+                .expect("could not initialize input buffer");
+
+            let wasmtime = wasmtime.clone();
+            tokio::task::spawn_local(async move {
+                // env.clone().threader.lock().unwrap().__reset_memory();
+
+                match wasmtime.lock().unwrap().start(&mut store, instance) {
+                    Ok(result) => println!("SUCCESS: handler returned {:?}", result),
+                    Err(error) => println!("ERROR: {}", error.to_string()),
+                }
+            })
+            .await
+            .unwrap();
+            // std::mem::drop(env.clone().threader);
+        }
+    })
+    .await;
 }

--- a/runtimes/hyper/Cargo.toml
+++ b/runtimes/hyper/Cargo.toml
@@ -15,7 +15,6 @@ serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = "0.2.0"
-#wasmer = "2.1.1"
 zip = "0.6"
 z85 = "3.0"
 

--- a/runtimes/hyper/Cargo.toml
+++ b/runtimes/hyper/Cargo.toml
@@ -15,9 +15,9 @@ serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = "0.2.0"
-wasmer = "2.1.1"
+#wasmer = "2.1.1"
 zip = "0.6"
 z85 = "3.0"
 
-assemblylift-core = { version = "0.4.0-alpha.2", path = "../../core" }
+assemblylift-core = { version = "0.4.0-alpha.10", path = "../../core" }
 assemblylift-core-iomod = { version = "0.4.0-alpha.0", path = "../../core/iomod" }

--- a/runtimes/hyper/Cargo.toml
+++ b/runtimes/hyper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assemblylift-hyper-runtime"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.10"
 edition = "2021"
 
 [dependencies]

--- a/runtimes/hyper/src/abi.rs
+++ b/runtimes/hyper/src/abi.rs
@@ -4,53 +4,31 @@ use std::io;
 use std::io::ErrorKind;
 
 use tracing::{debug, error, info};
-use wasmer::MemoryView;
+// use wasmer::MemoryView;
 
 use assemblylift_core::abi::RuntimeAbi;
-use assemblylift_core::threader::ThreaderEnv;
+use assemblylift_core::Caller;
+use assemblylift_core::wasm::{State, Wasmtime};
+// use assemblylift_core::threader::ThreaderEnv;
 
 use crate::Status;
 
 pub struct GenericDockerAbi;
 
 impl RuntimeAbi<Status> for GenericDockerAbi {
-    fn log(env: &ThreaderEnv<Status>, ptr: u32, len: u32) {
-        let s = ptr_to_string(env, ptr, len).unwrap();
+    fn log(mut caller: Caller<'_, State<Status>>, ptr: u32, len: u32) {
+        let s = Wasmtime::ptr_to_string(&mut caller, ptr, len).unwrap();
         info!("Guest: {}", s);
     }
 
-    fn success(env: &ThreaderEnv<Status>, ptr: u32, len: u32) {
+    fn success(mut caller: Caller<'_, State<Status>>, ptr: u32, len: u32) {
         debug!("called success");
-        let s = ptr_to_string(env, ptr, len).unwrap();
-        let tx = env.status_sender.clone();
+        let tx = caller.data().status_sender.clone();
+        let s = Wasmtime::ptr_to_string(&mut caller, ptr, len).unwrap();
         std::thread::spawn(move || {
-            if let Err(e) = tx.send(Status::Success(s)) {
+            if let Err(e) = tx.send(Status::Success(s.into())) {
                 error!("could not send status: {:?}", e.to_string())
             }
         });
     }
-}
-
-fn ptr_to_string<S>(env: &ThreaderEnv<S>, ptr: u32, len: u32) -> Result<String, io::Error>
-where
-    S: Clone + Send + Sized + 'static,
-{
-    let memory = env.memory_ref().unwrap();
-    let view: MemoryView<u8> = memory.view();
-
-    let mut str_vec: Vec<u8> = Vec::new();
-    for byte in view[ptr as usize..(ptr + len) as usize]
-        .iter()
-        .map(Cell::get)
-    {
-        str_vec.push(byte);
-    }
-
-    std::str::from_utf8(str_vec.as_slice())
-        .map(String::from)
-        .map_err(to_io_error)
-}
-
-fn to_io_error<E: Error>(err: E) -> io::Error {
-    io::Error::new(ErrorKind::Other, err.to_string())
 }

--- a/runtimes/hyper/src/abi.rs
+++ b/runtimes/hyper/src/abi.rs
@@ -1,8 +1,3 @@
-use std::cell::Cell;
-use std::error::Error;
-use std::io;
-use std::io::ErrorKind;
-
 use tracing::{debug, error, info};
 
 use assemblylift_core::abi::RuntimeAbi;

--- a/runtimes/hyper/src/abi.rs
+++ b/runtimes/hyper/src/abi.rs
@@ -4,12 +4,10 @@ use std::io;
 use std::io::ErrorKind;
 
 use tracing::{debug, error, info};
-// use wasmer::MemoryView;
 
 use assemblylift_core::abi::RuntimeAbi;
 use assemblylift_core::Caller;
 use assemblylift_core::wasm::{State, Wasmtime};
-// use assemblylift_core::threader::ThreaderEnv;
 
 use crate::Status;
 
@@ -17,14 +15,14 @@ pub struct GenericDockerAbi;
 
 impl RuntimeAbi<Status> for GenericDockerAbi {
     fn log(mut caller: Caller<'_, State<Status>>, ptr: u32, len: u32) {
-        let s = Wasmtime::ptr_to_string(&mut caller, ptr, len).unwrap();
+        let s = Wasmtime::<Self, Status>::ptr_to_string(&mut caller, ptr, len).unwrap();
         info!("Guest: {}", s);
     }
 
     fn success(mut caller: Caller<'_, State<Status>>, ptr: u32, len: u32) {
         debug!("called success");
         let tx = caller.data().status_sender.clone();
-        let s = Wasmtime::ptr_to_string(&mut caller, ptr, len).unwrap();
+        let s = Wasmtime::<Self, Status>::ptr_to_string(&mut caller, ptr, len).unwrap();
         std::thread::spawn(move || {
             if let Err(e) = tx.send(Status::Success(s.into())) {
                 error!("could not send status: {:?}", e.to_string())

--- a/runtimes/hyper/src/main.rs
+++ b/runtimes/hyper/src/main.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::sync::{Arc, Mutex};
 
 use clap::crate_version;
@@ -38,6 +39,9 @@ fn main() {
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
     info!("Starting AssemblyLift hyper runtime v{}", crate_version!());
+
+    // Mapped to /tmp inside the WASM module
+    fs::create_dir_all("/tmp/asmltmp").expect("could not create /tmp/asmltmp");
 
     let (registry_tx, registry_rx) = mpsc::channel(32);
     registry::spawn_registry(registry_rx).unwrap();

--- a/runtimes/hyper/src/main.rs
+++ b/runtimes/hyper/src/main.rs
@@ -5,7 +5,6 @@ use tokio::sync::mpsc;
 use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
 
-use assemblylift_core::wasm;
 use assemblylift_core::wasm::Wasmtime;
 use assemblylift_core_iomod::registry;
 
@@ -60,10 +59,8 @@ fn main() {
 
         let r = runner.clone();
         s.spawn(move |_| {
-            r.lock().unwrap().spawn();
+            r.lock().unwrap().spawn()
         });
-
-        // TODO spawn a scoped thread somewhere which handles memory channels
 
         s.spawn(move |_| {
             let mut launcher = Launcher::new();

--- a/runtimes/hyper/src/main.rs
+++ b/runtimes/hyper/src/main.rs
@@ -43,13 +43,8 @@ fn main() {
     let (registry_tx, registry_rx) = mpsc::channel(32);
     registry::spawn_registry(registry_rx).unwrap();
 
-    // let (module, store) = wasm::deserialize_module_from_path::<GenericDockerAbi, Status>(
-    //     "/opt/assemblylift",
-    //     &std::env::var("ASML_WASM_MODULE_NAME").unwrap_or("handler.wasm.bin".into()),
-    // )
-    // .expect("could not deserialize WASM module");
     let wasmtime = Arc::new(Mutex::new(
-        Wasmtime::<Status>::new_from_path(
+        Wasmtime::<GenericDockerAbi, Status>::new_from_path(
             format!(
                 "/opt/assemblylift/{}",
                 std::env::var("ASML_WASM_MODULE_NAME").unwrap_or("handler.wasm.bin".into())

--- a/runtimes/hyper/src/main.rs
+++ b/runtimes/hyper/src/main.rs
@@ -63,6 +63,8 @@ fn main() {
             r.lock().unwrap().spawn();
         });
 
+        // TODO spawn a scoped thread somewhere which handles memory channels
+
         s.spawn(move |_| {
             let mut launcher = Launcher::new();
             launcher.spawn(tx);

--- a/runtimes/hyper/src/runner.rs
+++ b/runtimes/hyper/src/runner.rs
@@ -10,8 +10,6 @@ use assemblylift_core_iomod::registry::RegistryTx;
 
 use crate::{GenericDockerAbi, Status, StatusTx};
 
-// use wasmer::{Module, Store};
-
 pub type RunnerTx = mpsc::Sender<RunnerMessage>;
 pub type RunnerRx = mpsc::Receiver<RunnerMessage>;
 pub type RunnerChannel = (RunnerTx, RunnerRx);
@@ -26,11 +24,11 @@ pub struct Runner {
     channel: RunnerChannel,
     registry_tx: RegistryTx,
     runtime: tokio::runtime::Runtime,
-    wasmtime: Arc<Mutex<Wasmtime<Status>>>,
+    wasmtime: Arc<Mutex<Wasmtime<GenericDockerAbi, Status>>>,
 }
 
 impl Runner {
-    pub fn new(registry_tx: RegistryTx, wasmtime: Arc<Mutex<Wasmtime<Status>>>) -> Self {
+    pub fn new(registry_tx: RegistryTx, wasmtime: Arc<Mutex<Wasmtime<GenericDockerAbi, Status>>>) -> Self {
         Runner {
             channel: mpsc::channel(32),
             registry_tx,
@@ -44,46 +42,21 @@ impl Runner {
         tokio::task::LocalSet::new().block_on(&self.runtime, async {
             while let Some(msg) = self.channel.1.recv().await {
                 debug!("received runner message");
-                // let mt = wasm::build_module::<GenericDockerAbi, Status>(
-                //     self.registry_tx.clone(),
-                //     msg.status_sender.clone(),
-                //     module.clone(),
-                //     module.name().unwrap_or("handler"),
-                //     store.clone(),
-                // )
-                // .expect("could not assemble module environment");
+
                 self.wasmtime
                     .lock()
                     .unwrap()
-                    .link_module(msg.status_sender.clone())
+                    .link_module(self.registry_tx.clone() , msg.status_sender.clone())
                     .expect("could not link wasm module");
 
-                // mt.1.host_input_buffer
-                //     .clone()
-                //     .lock()
-                //     .unwrap()
-                //     .initialize(msg.input);
                 self.wasmtime
                     .lock()
                     .unwrap()
                     .initialize_function_input_buffer(&msg.input)
                     .expect("could not initialize input buffer");
 
-                // let instance = match wasm::new_instance(module.clone(), mt.0.clone()) {
-                //     Ok(instance) => Arc::new(instance),
-                //     Err(why) => {
-                //         panic!("Unable to spin new WASM instance {}", why.to_string())
-                //     }
-                // };
                 let wasmtime = self.wasmtime.clone();
                 tokio::task::spawn_local(async move {
-                    // let start = instance.exports.get_function("_start").unwrap();
-                    // match start.call(&[]) {
-                    //     Ok(_) => msg.status_sender.send(Status::Exited(0)),
-                    //     Err(_) => msg
-                    //         .status_sender
-                    //         .send(Status::Failure("WASM module exited in error".to_string())),
-                    // }
                     match wasmtime.lock().unwrap().start() {
                         Ok(_) => msg.status_sender.send(Status::Exited(0)),
                         Err(_) => msg

--- a/runtimes/hyper/src/runner.rs
+++ b/runtimes/hyper/src/runner.rs
@@ -1,14 +1,16 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use tokio::sync::mpsc;
 use tracing::{debug, info};
-use wasmer::{Module, Store};
 
 use assemblylift_core::buffers::LinearBuffer;
 use assemblylift_core::wasm;
+use assemblylift_core::wasm::Wasmtime;
 use assemblylift_core_iomod::registry::RegistryTx;
 
 use crate::{GenericDockerAbi, Status, StatusTx};
+
+// use wasmer::{Module, Store};
 
 pub type RunnerTx = mpsc::Sender<RunnerMessage>;
 pub type RunnerRx = mpsc::Receiver<RunnerMessage>;
@@ -24,46 +26,65 @@ pub struct Runner {
     channel: RunnerChannel,
     registry_tx: RegistryTx,
     runtime: tokio::runtime::Runtime,
+    wasmtime: Arc<Mutex<Wasmtime<Status>>>,
 }
 
 impl Runner {
-    pub fn new(registry_tx: RegistryTx) -> Self {
+    pub fn new(registry_tx: RegistryTx, wasmtime: Arc<Mutex<Wasmtime<Status>>>) -> Self {
         Runner {
             channel: mpsc::channel(32),
             registry_tx,
             runtime: tokio::runtime::Runtime::new().unwrap(),
+            wasmtime,
         }
     }
 
-    pub fn spawn<'a>(&mut self, module: Arc<Module>, store: Arc<Store>) {
+    pub fn spawn<'a>(&mut self) {
         info!("Spawning runner");
         tokio::task::LocalSet::new().block_on(&self.runtime, async {
             while let Some(msg) = self.channel.1.recv().await {
                 debug!("received runner message");
-                let mt = wasm::build_module::<GenericDockerAbi, Status>(
-                    self.registry_tx.clone(),
-                    msg.status_sender.clone(),
-                    module.clone(),
-                    module.name().unwrap_or("handler"),
-                    store.clone(),
-                )
-                .expect("could not assemble module environment");
-
-                mt.1.host_input_buffer
-                    .clone()
+                // let mt = wasm::build_module::<GenericDockerAbi, Status>(
+                //     self.registry_tx.clone(),
+                //     msg.status_sender.clone(),
+                //     module.clone(),
+                //     module.name().unwrap_or("handler"),
+                //     store.clone(),
+                // )
+                // .expect("could not assemble module environment");
+                self.wasmtime
                     .lock()
                     .unwrap()
-                    .initialize(msg.input);
+                    .link_module(msg.status_sender.clone())
+                    .expect("could not link wasm module");
 
-                let instance = match wasm::new_instance(module.clone(), mt.0.clone()) {
-                    Ok(instance) => Arc::new(instance),
-                    Err(why) => {
-                        panic!("Unable to spin new WASM instance {}", why.to_string())
-                    }
-                };
+                // mt.1.host_input_buffer
+                //     .clone()
+                //     .lock()
+                //     .unwrap()
+                //     .initialize(msg.input);
+                self.wasmtime
+                    .lock()
+                    .unwrap()
+                    .initialize_function_input_buffer(&msg.input)
+                    .expect("could not initialize input buffer");
+
+                // let instance = match wasm::new_instance(module.clone(), mt.0.clone()) {
+                //     Ok(instance) => Arc::new(instance),
+                //     Err(why) => {
+                //         panic!("Unable to spin new WASM instance {}", why.to_string())
+                //     }
+                // };
+                let wasmtime = self.wasmtime.clone();
                 tokio::task::spawn_local(async move {
-                    let start = instance.exports.get_function("_start").unwrap();
-                    match start.call(&[]) {
+                    // let start = instance.exports.get_function("_start").unwrap();
+                    // match start.call(&[]) {
+                    //     Ok(_) => msg.status_sender.send(Status::Exited(0)),
+                    //     Err(_) => msg
+                    //         .status_sender
+                    //         .send(Status::Failure("WASM module exited in error".to_string())),
+                    // }
+                    match wasmtime.lock().unwrap().start() {
                         Ok(_) => msg.status_sender.send(Status::Exited(0)),
                         Err(_) => msg
                             .status_sender


### PR DESCRIPTION
This is pretty much a one-to-one translation, except for a few key points:
* Buffer traits & implementations have been condensed as well as had their semantics changed. Buffer calls like `first` and `next` now return the bytes to be written back to the caller rather than writing to the WASM memory themselves. This is to accommodate the access patterns of Wasmtime vs Wasmer (see next point)
* Wasmtime does not let you access a store from multiple threads, and wasmtime's `Caller` is not `Clone`; I could not find a way to get the memory & offset ptr from the Caller's store and then also pass the caller down to the buffer call which is "owned" by the store (i.e. circular store access is disallowed in wasmtime)
* The `expabi` ABI calls have been removed; they didn't work and aren't going to be fixed. This means Rust guests will need to update to the latest guest crate to avoid having the old calls definitions
* The functions in the `wasm` module have been refactored into the `Wasmtime` struct