### PR TITLE
[mainline] No underscores in large-function bucket name + delete dead code in CLI

### DIFF
--- a/cli/src/providers/aws_lambda.rs
+++ b/cli/src/providers/aws_lambda.rs
@@ -154,7 +154,7 @@ impl Castable for AwsLambdaProvider {
             .unwrap();
 
         let base_tmpl = LambdaBaseTemplate {
-            project_name: ctx.project.hostname().clone(),
+            project_name: ctx.project.name.clone(),
             options: self.options.clone(),
         };
         let hcl = Artifact {
@@ -290,7 +290,7 @@ impl Castable for LambdaService {
         .render();
 
         let function_subprovider = LambdaFunction {
-            service_name: service.hostname().clone(),
+            service_name: service.name.clone(),
         };
         let function_artifacts = ctx
             .functions

--- a/cli/src/providers/aws_lambda.rs
+++ b/cli/src/providers/aws_lambda.rs
@@ -269,6 +269,7 @@ impl Castable for LambdaService {
 
         let hcl_content = ServiceTemplate {
             project_name: ctx.project.name.clone(),
+            project_hostname: to_hostname(&ctx.project.name),
             service_name: service.name.clone(),
             service_hostname: to_hostname(&service.name),
             domain_name: String::from(
@@ -477,6 +478,7 @@ impl Template for LambdaBaseTemplate {
 #[derive(Serialize)]
 struct ServiceTemplate {
     project_name: String,
+    project_hostname: String,
     service_name: String,
     service_hostname: String,
     layer_name: String,
@@ -558,7 +560,7 @@ resource aws_apigatewayv2_stage {{service_name}}_default_stage {
 
 {{#if has_large_payloads}}resource aws_s3_bucket asml_{{service_name}}_functions {
     provider = aws.{{project_name}}-aws-lambda
-    bucket   = "asml-${local.project_name}-{{service_hostname}}-functions"
+    bucket   = "asml-{{project_hostname}}-{{service_hostname}}-functions"
 }
 resource aws_s3_bucket_acl functions {
     provider = aws.{{project_name}}-aws-lambda

--- a/cli/src/providers/aws_lambda.rs
+++ b/cli/src/providers/aws_lambda.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::fs;
 use std::fs::File;
 use std::io::Read;
@@ -7,14 +6,13 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::Arc;
 
-use handlebars::{Handlebars, to_json};
+use handlebars::Handlebars;
 use itertools::Itertools;
-use once_cell::sync::Lazy;
 use registry_common::models::GetIomodAtResponse;
 use serde::Serialize;
 
 use crate::archive;
-use crate::providers::{AWS_LAMBDA_PROVIDER_NAME, DNS_PROVIDERS, flatten, LockBox, Options, Provider, ProviderError, ProviderMap, render_string_list, render_string_map};
+use crate::providers::{AWS_LAMBDA_PROVIDER_NAME, flatten, to_hostname, Options, Provider, ProviderError, render_string_list, render_string_map};
 use crate::transpiler::{Artifact, Bindable, Bootable, Castable, CastError, ContentType, context, StringMap, Template};
 use crate::transpiler::context::{Context, Function};
 
@@ -156,7 +154,7 @@ impl Castable for AwsLambdaProvider {
             .unwrap();
 
         let base_tmpl = LambdaBaseTemplate {
-            project_name: ctx.project.name.clone(),
+            project_name: ctx.project.hostname().clone(),
             options: self.options.clone(),
         };
         let hcl = Artifact {
@@ -271,7 +269,8 @@ impl Castable for LambdaService {
 
         let hcl_content = ServiceTemplate {
             project_name: ctx.project.name.clone(),
-            service_name: name.clone(),
+            service_name: service.name.clone(),
+            service_hostname: to_hostname(&service.name),
             domain_name: String::from(
                 service
                     .domain_name
@@ -290,8 +289,7 @@ impl Castable for LambdaService {
         .render();
 
         let function_subprovider = LambdaFunction {
-            service_name: name.clone(),
-            options: self.options.clone(),
+            service_name: service.hostname().clone(),
         };
         let function_artifacts = ctx
             .functions
@@ -322,7 +320,6 @@ impl Castable for LambdaService {
 
 struct LambdaFunction {
     service_name: String,
-    options: Arc<Options>,
 }
 
 impl Castable for LambdaFunction {
@@ -337,13 +334,13 @@ impl Castable for LambdaFunction {
             .find(|&f| f.name == name)
         {
             Some(function) => {
-                let service = function.service_name.clone();
+                let service_name = function.service_name.clone();
 
                 // find dependencies for service
                 let iomod_names: Vec<String> = ctx
                     .iomods
                     .iter()
-                    .filter(|&m| *m.service_name == service.clone())
+                    .filter(|&m| *m.service_name == service_name.clone())
                     .map(|m| m.name.clone())
                     .collect();
 
@@ -353,7 +350,7 @@ impl Castable for LambdaFunction {
                         let authorizer = ctx
                             .authorizers
                             .iter()
-                            .filter(|a| a.service_name == service.clone())
+                            .filter(|a| a.service_name == service_name.clone())
                             .find(|a| a.id == id.clone())
                             .expect(&format!(
                                 "could not find authorizer by id \"{}\" in context",
@@ -365,7 +362,7 @@ impl Castable for LambdaFunction {
                                 "aws_iam" => None,
                                 _ => Some(format!(
                                     "aws_apigatewayv2_authorizer.{}_{}.id",
-                                    service.clone(),
+                                    service_name.clone(),
                                     id
                                 )),
                             },
@@ -394,7 +391,7 @@ impl Castable for LambdaFunction {
 
                 let tmpl = FunctionTemplate {
                     project_name: ctx.project.name.clone(),
-                    service_name: service.clone(),
+                    service_name: service_name.clone(),
                     function_name: function.name.clone(),
                     handler_name: match function.language.as_str() {
                         "rust" => format!("{}.{}", function.name.clone(), ext),
@@ -403,19 +400,19 @@ impl Castable for LambdaFunction {
                     },
                     runtime_layer: format!(
                         "aws_lambda_layer_version.asml_{}_runtime.arn",
-                        service.clone()
+                        service_name.clone()
                     ),
                     iomods_layer: match iomod_names.len() {
                         0 => None,
                         _ => Some(format!(
                             "aws_lambda_layer_version.asml_{}_iomods.arn",
-                            service.clone()
+                            service_name.clone()
                         )),
                     },
                     ruby_layer: match &*function.language {
                         "ruby" => Some(format!(
                             "aws_lambda_layer_version.asml_{}_ruby.arn",
-                            service.clone()
+                            service_name.clone()
                         )),
                         _ => None,
                     },
@@ -481,6 +478,7 @@ impl Template for LambdaBaseTemplate {
 struct ServiceTemplate {
     project_name: String,
     service_name: String,
+    service_hostname: String,
     layer_name: String,
     domain_name: String,
     has_iomods_layer: bool,
@@ -560,7 +558,7 @@ resource aws_apigatewayv2_stage {{service_name}}_default_stage {
 
 {{#if has_large_payloads}}resource aws_s3_bucket asml_{{service_name}}_functions {
     provider = aws.{{project_name}}-aws-lambda
-    bucket   = "asml-${local.project_name}-{{service_name}}-functions"
+    bucket   = "asml-${local.project_name}-{{service_hostname}}-functions"
 }
 resource aws_s3_bucket_acl functions {
     provider = aws.{{project_name}}-aws-lambda

--- a/cli/src/providers/gloo/mod.rs
+++ b/cli/src/providers/gloo/mod.rs
@@ -1,22 +1,20 @@
 use std::rc::Rc;
 use std::sync::Arc;
 
-use handlebars::{Handlebars, to_json};
+use handlebars::Handlebars;
 use itertools::Itertools;
 use jsonpath_lib::Selector;
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde::Serialize;
 
 use crate::providers::{
     KUBERNETES_PROVIDER_NAME, Options, Provider, ProviderError, ROUTE53_PROVIDER_NAME,
 };
 use crate::tools::cmctl::CmCtl;
-use crate::tools::glooctl::GlooCtl;
 use crate::tools::kubectl::KubeCtl;
 use crate::transpiler::{
     Artifact, Bindable, Bootable, Castable, CastError, ContentType, StringMap, Template,
 };
-use crate::transpiler::context::{Context, Domain, Function};
+use crate::transpiler::context::{Context, Function};
 
 pub struct ApiProvider {
     options: Arc<Options>,
@@ -29,6 +27,7 @@ impl ApiProvider {
         }
     }
 
+    #[allow(dead_code)] // Will need this eventually
     fn is_installed() -> bool {
         let kubectl = KubeCtl::default();
         let namespaces = kubectl.get_namespaces().unwrap();
@@ -283,71 +282,6 @@ impl Provider for ApiProvider {
         self.options = opts;
         Ok(())
     }
-}
-
-#[derive(Deserialize, Clone, Debug)]
-struct Status {
-    authorizations: Vec<Authorization>,
-}
-
-#[derive(Deserialize, Clone, Debug)]
-struct Authorization {
-    challenges: Vec<Challenge>,
-}
-
-#[derive(Deserialize, Clone, Debug)]
-struct Challenge {
-    r#type: String,
-    token: String,
-}
-
-#[derive(Deserialize, Clone, Debug)]
-struct VirtualService {
-    #[serde(rename = "apiVersion")]
-    api_version: String,
-    kind: String,
-    metadata: std::collections::HashMap<String, Value>,
-    spec: VirtualServiceSpec,
-}
-
-#[derive(Deserialize, Clone, Debug)]
-struct VirtualServiceSpec {
-    #[serde(rename = "virtualHost")]
-    virtual_host: VirtualHost,
-}
-
-#[derive(Deserialize, Clone, Debug)]
-struct VirtualHost {
-    domains: Vec<String>,
-    routes: Vec<Route>,
-}
-
-#[derive(Deserialize, Clone, Debug)]
-struct Route {
-    matchers: Vec<std::collections::HashMap<String, String>>,
-    #[serde(rename = "routeAction")]
-    route_action: RouteAction,
-}
-
-#[derive(Deserialize, Clone, Debug)]
-struct RouteAction {
-    single: RouteActionSingle,
-}
-
-#[derive(Deserialize, Clone, Debug)]
-struct RouteActionSingle {
-    upstream: Upstream,
-}
-
-#[derive(Deserialize, Clone, Debug)]
-struct Upstream {
-    metadata: Metadata,
-}
-
-#[derive(Deserialize, Clone, Debug)]
-struct Metadata {
-    name: String,
-    namespace: String,
 }
 
 #[derive(Serialize)]

--- a/cli/src/providers/k8s.rs
+++ b/cli/src/providers/k8s.rs
@@ -1,14 +1,12 @@
-use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
 
 use clap::crate_version;
 use handlebars::Handlebars;
 use itertools::Itertools;
-use once_cell::sync::Lazy;
 use serde::Serialize;
 
-use crate::providers::{DNS_PROVIDERS, flatten, gloo, KUBERNETES_PROVIDER_NAME, LockBox, Options, Provider, ProviderError, ProviderMap};
+use crate::providers::{flatten, gloo, KUBERNETES_PROVIDER_NAME, Options, Provider, ProviderError};
 use crate::tools::glooctl::GlooCtl;
 use crate::transpiler::{Artifact, Bindable, Bootable, Castable, CastError, ContentType, context, StringMap, Template};
 use crate::transpiler::context::Context;
@@ -102,7 +100,7 @@ impl Bindable for KubernetesProvider {
         ctx.services
             .iter()
             .filter(|&s| s.provider.name == self.name())
-            .map(|s| self.service_subprovider.bind(ctx.clone()))
+            .map(|_| self.service_subprovider.bind(ctx.clone()))
             .collect_vec();
         Ok(())
     }
@@ -148,7 +146,6 @@ impl Castable for KubernetesService {
 
         let function_subprovider = KubernetesFunction {
             service_name: name.clone(),
-            options: self.options.clone(),
         };
         let function_artifacts = ctx
             .functions
@@ -194,7 +191,6 @@ impl Bindable for KubernetesService {
 
 struct KubernetesFunction {
     service_name: String,
-    options: Arc<Options>,
 }
 
 impl Castable for KubernetesFunction {

--- a/cli/src/providers/mod.rs
+++ b/cli/src/providers/mod.rs
@@ -6,7 +6,6 @@ use once_cell::sync::Lazy;
 use crate::transpiler::{Artifact, Bindable, Bootable, Castable, StringMap};
 
 pub mod aws_lambda;
-pub mod aws_lambda_alpine;
 pub mod gloo;
 pub mod k8s;
 pub mod route53;
@@ -63,6 +62,10 @@ pub trait Provider: Castable + Bindable + Bootable {
 #[derive(Debug)]
 pub enum ProviderError {
     TransformationError(String),
+}
+
+fn to_hostname(name: &str) -> String {
+    name.replace("_", "-")
 }
 
 fn render_string_list(list: Rc<Vec<String>>) -> String {

--- a/cli/src/tools/kubectl.rs
+++ b/cli/src/tools/kubectl.rs
@@ -3,7 +3,6 @@ use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-use itertools::Itertools;
 use serde_json::Value;
 
 use crate::tools::Tool;
@@ -32,7 +31,7 @@ impl KubeCtl {
 
     pub fn apply(&self) -> Result<(), String> {
         println!("Applying kubernetes configuration...");
-        let mut child = self
+        let child = self
             .command()
             .arg("apply")
             .arg("-f")
@@ -88,7 +87,7 @@ impl KubeCtl {
     }
 
     pub fn get_namespaces(&self) -> Result<Value, String> {
-        let mut child = self
+        let child = self
             .command()
             .args(vec!["get", "namespaces"])
             .arg("-o")
@@ -103,7 +102,7 @@ impl KubeCtl {
     }
 
     pub fn get(&self, kind: &str) -> Result<Value, String> {
-        let mut child = self
+        let child = self
             .command()
             .args(vec!["get", kind])
             .args(vec!["-o", "json"])
@@ -137,7 +136,7 @@ impl KubeCtl {
                 a
             })
             .unwrap_or(Default::default());
-        let mut child = self
+        let child = self
             .command()
             .args(vec!["get", kind])
             .args(vec!["-n", ns])

--- a/cli/src/tools/mod.rs
+++ b/cli/src/tools/mod.rs
@@ -6,7 +6,9 @@ use std::process::Command;
 use flate2::read::GzDecoder;
 
 pub mod cmctl;
+#[allow(dead_code)]
 pub mod glooctl;
+#[allow(dead_code)]
 pub mod kubectl;
 
 pub trait Tool {

--- a/cli/src/transpiler/context.rs
+++ b/cli/src/transpiler/context.rs
@@ -317,12 +317,6 @@ pub struct Project {
     //    pub version: String,
 }
 
-impl Project {
-    pub fn hostname(&self) -> String {
-        self.name.replace("_", "-")
-    }
-}
-
 pub struct Terraform {
     pub state_bucket_name: String,
     pub lock_table_name: String,
@@ -346,12 +340,6 @@ pub struct Service {
     pub is_root: Option<bool>,
     pub domain_name: Option<String>,
     pub project_name: String,
-}
-
-impl Service {
-    pub fn hostname(&self) -> String {
-        self.name.replace("_", "-")
-    }
 }
 
 #[derive(Serialize)]

--- a/cli/src/transpiler/context.rs
+++ b/cli/src/transpiler/context.rs
@@ -39,7 +39,7 @@ impl Context {
         let mut ctx_functions: Vec<Function> = Vec::new();
         let mut ctx_authorizers: Vec<Authorizer> = Vec::new();
         let mut ctx_iomods: Vec<Iomod> = Vec::new();
-        let mut ctx_registries: Vec<Registry> = manifest
+        let ctx_registries: Vec<Registry> = manifest
             .registries
             .unwrap_or(Vec::new())
             .iter()
@@ -48,7 +48,7 @@ impl Context {
                 options: r.options.clone(),
             })
             .collect();
-        let mut ctx_domains = manifest
+        let ctx_domains = manifest
             .domains
             .unwrap_or(Vec::new())
             .iter()
@@ -224,7 +224,7 @@ impl Castable for Context {
         hcl_content.push_str(&*tmpl.render());
 
         // FIXME dedupe by name (there's only one provider possible rn)
-        let mut dns_providers = ctx.domains.iter().map(|d| d.provider.clone()).collect_vec();
+        let dns_providers = ctx.domains.iter().map(|d| d.provider.clone()).collect_vec();
         for dns in dns_providers {
             let provider = DNS_PROVIDERS
                 .get(&*dns.name.clone())
@@ -317,6 +317,12 @@ pub struct Project {
     //    pub version: String,
 }
 
+impl Project {
+    pub fn hostname(&self) -> String {
+        self.name.replace("_", "-")
+    }
+}
+
 pub struct Terraform {
     pub state_bucket_name: String,
     pub lock_table_name: String,
@@ -343,8 +349,8 @@ pub struct Service {
 }
 
 impl Service {
-    pub fn option(&self, name: &str) -> Option<&String> {
-        self.provider.options.get(name)
+    pub fn hostname(&self) -> String {
+        self.name.replace("_", "-")
     }
 }
 


### PR DESCRIPTION
This addresses #100 for the Lambda provider when creating an S3 bucket for large functions.