### PR TITLE
[0.4.0-beta] Add environment variable for function precompile flag in Hyper Runtime

### DIFF
--- a/cli/src/providers/k8s/mod.rs
+++ b/cli/src/providers/k8s/mod.rs
@@ -296,6 +296,10 @@ impl Castable for KubernetesFunction {
                         hcl_tmpl.service_name.clone(),
                         hcl_tmpl.function_name.clone()
                     ),
+                    function_precompiled: match function.precompile {
+                        true => "true".into(),
+                        false => "false".into(),
+                    },
                     is_ruby: hcl_tmpl.is_ruby,
                 }
                 .render();

--- a/cli/src/providers/k8s/templates.rs
+++ b/cli/src/providers/k8s/templates.rs
@@ -288,6 +288,7 @@ pub struct DockerfileTemplate {
     pub function_name: String,
     pub handler_name: String,
     pub function_coordinates: String,
+    pub function_precompiled: String,
     pub is_ruby: bool,
 }
 
@@ -303,6 +304,7 @@ impl Template for DockerfileTemplate {
         r#"FROM public.ecr.aws/akkoro/assemblylift/hyper-alpine:{{base_image_version}}
 ENV ASML_WASM_MODULE_NAME {{handler_name}}
 ENV ASML_FUNCTION_COORDINATES {{function_coordinates}}
+ENV ASML_FUNCTION_PRECOMPILED {{function_precompiled}}
 {{#if is_ruby}}ENV ASML_FUNCTION_ENV ruby-docker{{/if}}
 ADD ./{{function_name}}/{{handler_name}} /opt/assemblylift/projects/{{project_name}}/services/{{service_name}}/{{handler_name}}
 {{#if is_ruby}}COPY ./ruby-wasm32-wasi /usr/bin/ruby-wasm32-wasi


### PR DESCRIPTION
* IFF `ASML_FUNCTION_PRECOMPILED` is set to `false` then load .wasm, otherwise load .wasm.bin
* set `ASML_FUNCTION_PRECOMPILED` in Hyper runtime Dockerfile